### PR TITLE
Fix filter bug in MessagesTemplate.cs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,42 @@
+# ASP.NET Core
+# Build and test ASP.NET Core projects targeting .NET Core.
+# Add steps that run tests, create a NuGet package, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
+
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'restore'
+    projects: '**/*.csproj'
+    feedsToUse: 'select'
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'build'
+    projects: '**/*.csproj'
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'pack'
+    packagesToPack: '**/*.csproj'
+    versioningScheme: 'byBuildNumber'
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'push'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+    nuGetFeedType: 'internal'
+    publishVstsFeed: 'b4ea31b1-d483-4276-9136-a4e2adc28303'
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    ArtifactName: 'drop'
+    publishLocation: 'Container'

--- a/src/OpenProtocolInterpreter/_internals/Messages/MessagesTemplate.cs
+++ b/src/OpenProtocolInterpreter/_internals/Messages/MessagesTemplate.cs
@@ -33,7 +33,7 @@ namespace OpenProtocolInterpreter.Messages
                 return;
 
             var type = mode == InterpreterMode.Controller ? typeof(IIntegrator) : typeof(IController);
-            var selectedMids = _templates.Values.Where(x => x.Type.IsAssignableFrom(type));
+            var selectedMids = _templates.Values.Where(x => type.IsAssignableFrom(x.Type));
             FilterSelectedMids(selectedMids);
         }
 


### PR DESCRIPTION
Hi,
I think I found a bug in the new MidInterpreter filter message by mode feature.

When I set up my MidInterpreter in Controller mode I should be able parse for example Mid0001, however I can not today.

But with this fix it should work