### PR TITLE
Minor fixes to Mid0002 and Mid0003

### DIFF
--- a/src/OpenProtocolInterpreter/Communication/Mid0002.cs
+++ b/src/OpenProtocolInterpreter/Communication/Mid0002.cs
@@ -278,8 +278,8 @@ namespace OpenProtocolInterpreter.Communication
                 {
                     1, new List<DataField>()
                             {
-                                new DataField((int)DataFields.CELL_ID, 20, 4, '0'),
-                                new DataField((int)DataFields.CHANNEL_ID, 26, 2, '0'),
+                                new DataField((int)DataFields.CELL_ID, 20, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                new DataField((int)DataFields.CHANNEL_ID, 26, 2, '0', DataField.PaddingOrientations.LEFT_PADDED),
                                 new DataField((int)DataFields.CONTROLLER_NAME, 30, 25, ' ')
                             }
                 },

--- a/src/OpenProtocolInterpreter/Communication/Mid0003.cs
+++ b/src/OpenProtocolInterpreter/Communication/Mid0003.cs
@@ -5,10 +5,10 @@
     /// Description:
     ///     This message disables the communication. The controller will stop to respond to any commands
     ///     except for MID 0001 Communication start after receiving this command.
-    /// Message sent by: Controller
+    /// Message sent by: Integrator
     /// Answer: MID 0005 Command accepted
     /// </summary>
-    public class Mid0003 : Mid, ICommunication, IController
+    public class Mid0003 : Mid, ICommunication, IIntegrator
     {
         private const int LAST_REVISION = 1;
         public const int MID = 3;


### PR DESCRIPTION
Two small but important fixes to Mid0002 and Mid0003. Please carefully review their correctness.

* I believe numerical parameters should be left-padded with '0' but they were right-padded in Mid0002.

> If the Parameter value is specified only by ASCII digits,
then the parameter value is padded on the left with the
ASCII characters ‘0’ - Open Protocol specification 

* I think Mid0003 should inherit IIntegrator, not IController. There is, I believe a typo in the official specification. It says "Message sent by: Controller", but then above that it says:

> The controller will stop to respond to any commands except for
MID 0001 Communication start after receiving this command

... implying that it is the controller that receives the message, and the integrator that sends it.

I have tested this with an official Open Protocol Simulator and these fixes seem to be correct.