### PR TITLE
Handling string packages for Mid0061

### DIFF
--- a/src/MIDTesters.Core/Tightening/TestMid0061.cs
+++ b/src/MIDTesters.Core/Tightening/TestMid0061.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenProtocolInterpreter.Tightening;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenProtocolInterpreter.Tightening;
 
 namespace MIDTesters.Tightening
 {
@@ -78,6 +77,59 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision2()
+        {
+            var pack = "03850061002         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:53";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision2()
         {
             List<byte> bytes = new List<byte>();
 
@@ -163,6 +215,62 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision3()
+        {
+            var pack = "04190061003         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       4824905";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision3()
         {
             List<byte> bytes = new List<byte>();
 
@@ -251,6 +359,65 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision4()
+        {
+            var pack = "05000061004         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       482490550Identifier result part 2 51Identifier result part 3 52Identifier result part 4 ";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.IsNotNull(mid.IdentifierResultPart2);
+            Assert.IsNotNull(mid.IdentifierResultPart3);
+            Assert.IsNotNull(mid.IdentifierResultPart4);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision4()
         {
             List<byte> bytes = new List<byte>();
 
@@ -343,6 +510,66 @@ namespace MIDTesters.Tightening
         [TestMethod]
         public void Mid0061Revision5()
         {
+            var pack = "05060061005         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       482490550Identifier result part 2 51Identifier result part 3 52Identifier result part 4 53E124";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.IsNotNull(mid.IdentifierResultPart2);
+            Assert.IsNotNull(mid.IdentifierResultPart3);
+            Assert.IsNotNull(mid.IdentifierResultPart4);
+            Assert.IsNotNull(mid.CustomerTighteningErrorCode);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision5()
+        {
             List<byte> bytes = new List<byte>();
 
             var strategyOptions = new byte[] //5 bytes long
@@ -434,6 +661,68 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision6()
+        {          
+            var pack = "05260061006         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       482490550Identifier result part 2 51Identifier result part 3 52Identifier result part 4 53E12454001500550000000042";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.IsNotNull(mid.IdentifierResultPart2);
+            Assert.IsNotNull(mid.IdentifierResultPart3);
+            Assert.IsNotNull(mid.IdentifierResultPart4);
+            Assert.IsNotNull(mid.CustomerTighteningErrorCode);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateValue);
+            Assert.IsNotNull(mid.TighteningErrorStatus2);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision6()
         {
             List<byte> bytes = new List<byte>();
 
@@ -545,6 +834,70 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision7()
+        {
+            var pack = "05440061007         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       482490550Identifier result part 2 51Identifier result part 3 52Identifier result part 4 53E12454001500550000000042560010000570999900";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.IsNotNull(mid.IdentifierResultPart2);
+            Assert.IsNotNull(mid.IdentifierResultPart3);
+            Assert.IsNotNull(mid.IdentifierResultPart4);
+            Assert.IsNotNull(mid.CustomerTighteningErrorCode);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateValue);
+            Assert.IsNotNull(mid.TighteningErrorStatus2);
+            Assert.IsNotNull(mid.CompensatedAngle);
+            Assert.IsNotNull(mid.FinalAngleDecimal);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision7()
         {
             List<byte> bytes = new List<byte>();
 
@@ -661,6 +1014,71 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision998()
+        {
+            var pack = "05580061998         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       482490550Identifier result part 2 51Identifier result part 3 52Identifier result part 4 53E1245400150055000000004256025702580200000010001200000080";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.IsNotNull(mid.IdentifierResultPart2);
+            Assert.IsNotNull(mid.IdentifierResultPart3);
+            Assert.IsNotNull(mid.IdentifierResultPart4);
+            Assert.IsNotNull(mid.CustomerTighteningErrorCode);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateValue);
+            Assert.IsNotNull(mid.TighteningErrorStatus2);
+            Assert.IsNotNull(mid.NumberOfStagesInMultistage);
+            Assert.IsNotNull(mid.NumberOfStageResults);
+            Assert.IsNotNull(mid.StageResults);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision998()
         {
             List<byte> bytes = new List<byte>();
 

--- a/src/MIDTesters/Tightening/TestMid0061.cs
+++ b/src/MIDTesters/Tightening/TestMid0061.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenProtocolInterpreter.Tightening;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenProtocolInterpreter.Tightening;
 
 namespace MIDTesters.Tightening
 {
@@ -78,6 +77,59 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision2()
+        {
+            var pack = "03850061002         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:53";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision2()
         {
             List<byte> bytes = new List<byte>();
 
@@ -163,6 +215,62 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision3()
+        {
+            var pack = "04190061003         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       4824905";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision3()
         {
             List<byte> bytes = new List<byte>();
 
@@ -251,6 +359,65 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision4()
+        {
+            var pack = "05000061004         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       482490550Identifier result part 2 51Identifier result part 3 52Identifier result part 4 ";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.IsNotNull(mid.IdentifierResultPart2);
+            Assert.IsNotNull(mid.IdentifierResultPart3);
+            Assert.IsNotNull(mid.IdentifierResultPart4);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision4()
         {
             List<byte> bytes = new List<byte>();
 
@@ -342,6 +509,66 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision5()
+        {
+            var pack = "05060061005         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       482490550Identifier result part 2 51Identifier result part 3 52Identifier result part 4 53E124";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.IsNotNull(mid.IdentifierResultPart2);
+            Assert.IsNotNull(mid.IdentifierResultPart3);
+            Assert.IsNotNull(mid.IdentifierResultPart4);
+            Assert.IsNotNull(mid.CustomerTighteningErrorCode);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision5()
         {
             List<byte> bytes = new List<byte>();
 
@@ -435,6 +662,68 @@ namespace MIDTesters.Tightening
         [TestMethod]
         public void Mid0061Revision6()
         {
+            var pack = "05260061006         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       482490550Identifier result part 2 51Identifier result part 3 52Identifier result part 4 53E12454001500550000000042";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.IsNotNull(mid.IdentifierResultPart2);
+            Assert.IsNotNull(mid.IdentifierResultPart3);
+            Assert.IsNotNull(mid.IdentifierResultPart4);
+            Assert.IsNotNull(mid.CustomerTighteningErrorCode);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateValue);
+            Assert.IsNotNull(mid.TighteningErrorStatus2);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision6()
+        {
             List<byte> bytes = new List<byte>();
 
             var strategyOptions = new byte[] //5 bytes long
@@ -463,7 +752,7 @@ namespace MIDTesters.Tightening
             {
                 0x2A, //0010 1010
                 0x00, //Reserved from bit 7 to rest
-                0x00, 
+                0x00,
                 0x00,
                 0x00,
                 0x00,
@@ -545,6 +834,70 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision7()
+        {
+            var pack = "05440061007         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       482490550Identifier result part 2 51Identifier result part 3 52Identifier result part 4 53E12454001500550000000042560010000570999900";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.IsNotNull(mid.IdentifierResultPart2);
+            Assert.IsNotNull(mid.IdentifierResultPart3);
+            Assert.IsNotNull(mid.IdentifierResultPart4);
+            Assert.IsNotNull(mid.CustomerTighteningErrorCode);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateValue);
+            Assert.IsNotNull(mid.TighteningErrorStatus2);
+            Assert.IsNotNull(mid.CompensatedAngle);
+            Assert.IsNotNull(mid.FinalAngleDecimal);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision7()
         {
             List<byte> bytes = new List<byte>();
 
@@ -661,6 +1014,71 @@ namespace MIDTesters.Tightening
 
         [TestMethod]
         public void Mid0061Revision998()
+        {
+            var pack = "05580061998         010000020003RA ST6.2 ETV100          04                         05000006001070208000670900001000001101221301401501611711811912000000081942100340022004600230040002400050525000202600420270000028000002900100300085031000043200033150340003500000036999900370000003800000039000000400000004100001848874200000430000044      C0761275452020-06-25:01:04:39462020-06-24:10:48:5347Test Parameter Set       482490550Identifier result part 2 51Identifier result part 3 52Identifier result part 4 53E1245400150055000000004256025702580200000010001200000080";
+            var mid = _midInterpreter.Parse<Mid0061>(pack);
+
+            Assert.AreEqual(typeof(Mid0061), mid.GetType());
+            Assert.IsNotNull(mid.CellId);
+            Assert.IsNotNull(mid.ChannelId);
+            Assert.IsNotNull(mid.TorqueControllerName);
+            Assert.IsNotNull(mid.VinNumber);
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.Strategy);
+            Assert.IsNotNull(mid.StrategyOptions);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.BatchCounter);
+            Assert.IsNotNull(mid.TighteningStatus);
+            Assert.IsNotNull(mid.BatchStatus);
+            Assert.IsNotNull(mid.TorqueStatus);
+            Assert.IsNotNull(mid.AngleStatus);
+            Assert.IsNotNull(mid.RundownAngleStatus);
+            Assert.IsNotNull(mid.CurrentMonitoringStatus);
+            Assert.IsNotNull(mid.SelftapStatus);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateStatus);
+            Assert.IsNotNull(mid.TighteningErrorStatus);
+            Assert.IsNotNull(mid.TorqueMinLimit);
+            Assert.IsNotNull(mid.TorqueMaxLimit);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.Torque);
+            Assert.IsNotNull(mid.AngleMinLimit);
+            Assert.IsNotNull(mid.AngleMaxLimit);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.Angle);
+            Assert.IsNotNull(mid.RundownAngle);
+            Assert.IsNotNull(mid.CurrentMonitoringMin);
+            Assert.IsNotNull(mid.CurrentMonitoringMax);
+            Assert.IsNotNull(mid.CurrentMonitoringValue);
+            Assert.IsNotNull(mid.SelftapMin);
+            Assert.IsNotNull(mid.SelftapMax);
+            Assert.IsNotNull(mid.SelftapTorque);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMin);
+            Assert.IsNotNull(mid.PrevailTorqueMonitoringMax);
+            Assert.IsNotNull(mid.PrevailTorque);
+            Assert.IsNotNull(mid.TighteningId);
+            Assert.IsNotNull(mid.JobSequenceNumber);
+            Assert.IsNotNull(mid.SyncTighteningId);
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.Timestamp);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.TorqueValuesUnit);
+            Assert.IsNotNull(mid.ResultType);
+            Assert.IsNotNull(mid.IdentifierResultPart2);
+            Assert.IsNotNull(mid.IdentifierResultPart3);
+            Assert.IsNotNull(mid.IdentifierResultPart4);
+            Assert.IsNotNull(mid.CustomerTighteningErrorCode);
+            Assert.IsNotNull(mid.PrevailTorqueCompensateValue);
+            Assert.IsNotNull(mid.TighteningErrorStatus2);
+            Assert.IsNotNull(mid.NumberOfStagesInMultistage);
+            Assert.IsNotNull(mid.NumberOfStageResults);
+            Assert.IsNotNull(mid.StageResults);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0061ByteRevision998()
         {
             List<byte> bytes = new List<byte>();
 


### PR DESCRIPTION
This solves issue #24 and removes the `Obsolete` attribute from `Parse(string package)` and `Pack()` methods.

The approach was to convert to int then to byte[].