### PR TITLE
Handling comma decimal separator

### DIFF
--- a/src/OpenProtocolInterpreter/_internals/Converters/DecimalConverter.cs
+++ b/src/OpenProtocolInterpreter/_internals/Converters/DecimalConverter.cs
@@ -8,7 +8,7 @@ namespace OpenProtocolInterpreter.Converters
         {
             decimal decimalValue = 0;
             if (value != null)
-                decimal.TryParse(value.ToString(), out decimalValue);
+                decimal.TryParse(value.Replace(',', '.'), out decimalValue);
 
             return decimalValue;
         }


### PR DESCRIPTION
Parsing from decimal to string won't change since it's the default of open protocol. This solves #26 issue.