### PR TITLE
Fix Mid0140 (dynamic Job)

### DIFF
--- a/src/OpenProtocolInterpreter/Converters/AdvancedJobListConverter.cs
+++ b/src/OpenProtocolInterpreter/Converters/AdvancedJobListConverter.cs
@@ -36,7 +36,7 @@ namespace OpenProtocolInterpreter.Converters
                 advancedJobsList.Add(string.Join(":", fields));
             }
 
-            return string.Join(";", advancedJobsList);
+            return string.Join(";", advancedJobsList) + ";";
         }
 
         public override string Convert(char paddingChar, int size, DataField.PaddingOrientations orientation, IEnumerable<AdvancedJob> value) => Convert(value);

--- a/src/OpenProtocolInterpreter/Job/Advanced/Mid0140.cs
+++ b/src/OpenProtocolInterpreter/Job/Advanced/Mid0140.cs
@@ -183,7 +183,7 @@ namespace OpenProtocolInterpreter.Job.Advanced
                                         new DataField((int)DataFields.BATCH_STATUS_AT_INCREMENT, 0, 1),
                                         new DataField((int)DataFields.DECREMENT_BATCH_AT_OK_LOOSENING, 0, 1),
                                         new DataField((int)DataFields.MAX_TIME_FOR_FIRST_TIGHTENING, 0, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
-                                        new DataField((int)DataFields.MAX_TIME_TO_COMPLETE_JOB, 0, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                        new DataField((int)DataFields.MAX_TIME_TO_COMPLETE_JOB, 0, 5, '0', DataField.PaddingOrientations.LEFT_PADDED),
                                         new DataField((int)DataFields.DISPLAY_RESULT_AT_AUTO_SELECT, 0, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
                                         new DataField((int)DataFields.USE_LINE_CONTROL, 0, 1),
                                         new DataField((int)DataFields.IDENTIFIER_RESULT_PART, 0, 1),


### PR DESCRIPTION
After trying to use dynamic jobs on a Power Focus using this awesome interpreter, I've found out that it wasn't packing the Mid0140 properly. According to [this specification](https://issuu.com/wellingtontelles/docs/openprotocol_specification_1_), pages 132 and 133, each job from Job List must be terminated by ";" (the interpreter was missing the ";" after the last job listed) and MAX_TIME_TO_COMPLETE_JOB is actually five ASCII digits, instead of four.
