### PR TITLE
Add new Tightening Error Status 2 to mid0061

### DIFF
--- a/src/MIDTesters/Tightening/TestMid0061.cs
+++ b/src/MIDTesters/Tightening/TestMid0061.cs
@@ -750,10 +750,10 @@ namespace MIDTesters.Tightening
 
             var tighteningErrorStatus2 = new byte[] //10 bytes long
             {
-                0x2A, //0010 1010
-                0x00, //Reserved from bit 7 to rest
-                0x00,
-                0x00,
+                0xAA, //1010 1010
+                0x03, //0000 0011 
+                0x02, //0000 0010
+                0x00, //Reserved from bit 19 to rest
                 0x00,
                 0x00,
                 0x00,
@@ -925,10 +925,10 @@ namespace MIDTesters.Tightening
 
             var tighteningErrorStatus2 = new byte[] //10 bytes long
             {
-                0x2A, //0010 1010
-                0x00, //Reserved from bit 7 to rest
-                0x00,
-                0x00,
+                0xAA, //1010 1010
+                0x03, //0000 0011 
+                0x02, //0000 0010
+                0x00, //Reserved from bit 19 to rest
                 0x00,
                 0x00,
                 0x00,
@@ -1106,10 +1106,10 @@ namespace MIDTesters.Tightening
 
             var tighteningErrorStatus2 = new byte[] //10 bytes long
             {
-                0x2A, //0010 1010
-                0x00, //Reserved from bit 7 to rest
-                0x00,
-                0x00,
+                0xAA, //1010 1010
+                0x03, //0000 0011 
+                0x02, //0000 0010
+                0x00, //Reserved from bit 19 to rest
                 0x00,
                 0x00,
                 0x00,

--- a/src/OpenProtocolInterpreter/Converters/TighteningErrorStatusConverter.cs
+++ b/src/OpenProtocolInterpreter/Converters/TighteningErrorStatusConverter.cs
@@ -192,11 +192,31 @@ namespace OpenProtocolInterpreter.Converters
                     value.GradientMonitoringHigh,
                     value.GradientMonitoringLow,
                     value.ReactionBarFailed,
-                    GetBit(value.Reserved[0], 7),
-                    GetBit(value.Reserved[0], 8)
+                    value.SnugMax,
+                    value.CycleAbort,
                 }),
-                value.Reserved[1],
-                value.Reserved[2],
+                SetByte(new bool[]
+                {
+                    value.NeckingFailure,
+                    value.EffectiveLoosening,
+                    value.OverSpeed,
+                    value.NoResidualTorque,
+                    value.PositioningFail,
+                    value.SnugMonLow,
+                    value.SnugMonHigh,
+                    value.DynamicMinCurrent,
+                }),
+                SetByte(new bool[]
+                {
+                    value.DynamicMaxCurrent,
+                    value.LatentResult,
+                    GetBit(value.Reserved[2], 3),
+                    GetBit(value.Reserved[2], 4),
+                    GetBit(value.Reserved[2], 5),
+                    GetBit(value.Reserved[2], 6),
+                    GetBit(value.Reserved[2], 7),
+                    GetBit(value.Reserved[2], 8)
+                }),
                 value.Reserved[3],
                 value.Reserved[4],
                 value.Reserved[5],

--- a/src/OpenProtocolInterpreter/Converters/TighteningErrorStatusConverter.cs
+++ b/src/OpenProtocolInterpreter/Converters/TighteningErrorStatusConverter.cs
@@ -156,11 +156,23 @@ namespace OpenProtocolInterpreter.Converters
                 GradientMonitoringHigh = GetBit(value[0], 4),
                 GradientMonitoringLow = GetBit(value[0], 5),
                 ReactionBarFailed = GetBit(value[0], 6),
+                SnugMax = GetBit(value[0], 7),
+                CycleAbort = GetBit(value[0], 8),
+                NeckingFailure = GetBit(value[0], 9),
+                EffectiveLoosening = GetBit(value[0], 10),
+                OverSpeed = GetBit(value[0], 11),
+                NoResidualTorque = GetBit(value[0], 12),
+                PositioningFail = GetBit(value[0], 13),
+                SnugMonLow = GetBit(value[0], 14),
+                SnugMonHigh = GetBit(value[0], 15),
+                DynamicMinCurrent = GetBit(value[0], 16),
+                DynamicMacCurrent = GetBit(value[0], 17),
+                LatentResult = GetBit(value[0], 18),
                 Reserved = new byte[10]
             };
 
-            //set only 7 and 8 bytes to reserved
-            obj.Reserved[0] = SetByte(new bool[] { GetBit(value[0], 7), GetBit(value[0], 8), false, false, false, false, false, false });
+            //set only 19 and 20 bytes to reserved
+            obj.Reserved[0] = SetByte(new bool[] { GetBit(value[0], 19), GetBit(value[0], 20), false, false, false, false, false, false });
 
             return obj;
         }

--- a/src/OpenProtocolInterpreter/Converters/TighteningErrorStatusConverter.cs
+++ b/src/OpenProtocolInterpreter/Converters/TighteningErrorStatusConverter.cs
@@ -150,6 +150,7 @@ namespace OpenProtocolInterpreter.Converters
         {
             var obj = new TighteningErrorStatus2()
             {
+                //byte 0
                 DriveDeactivated = GetBit(value[0], 1),
                 ToolStall = GetBit(value[0], 2),
                 DriveHot = GetBit(value[0], 3),
@@ -157,7 +158,8 @@ namespace OpenProtocolInterpreter.Converters
                 GradientMonitoringLow = GetBit(value[0], 5),
                 ReactionBarFailed = GetBit(value[0], 6),
                 SnugMax = GetBit(value[0], 7),
-                CycleAbort = GetBit(value[1], 0),
+                CycleAbort = GetBit(value[0], 8),
+                //byte 1
                 NeckingFailure = GetBit(value[1], 1),
                 EffectiveLoosening = GetBit(value[1], 2),
                 OverSpeed = GetBit(value[1], 3),
@@ -165,7 +167,8 @@ namespace OpenProtocolInterpreter.Converters
                 PositioningFail = GetBit(value[1], 5),
                 SnugMonLow = GetBit(value[1], 6),
                 SnugMonHigh = GetBit(value[1], 7),
-                DynamicMinCurrent = GetBit(value[2], 0),
+                DynamicMinCurrent = GetBit(value[1], 8),
+                //byte 2
                 DynamicMaxCurrent = GetBit(value[2], 1),
                 LatentResult = GetBit(value[2], 2),
                 Reserved = new byte[10]

--- a/src/OpenProtocolInterpreter/Converters/TighteningErrorStatusConverter.cs
+++ b/src/OpenProtocolInterpreter/Converters/TighteningErrorStatusConverter.cs
@@ -166,7 +166,7 @@ namespace OpenProtocolInterpreter.Converters
                 SnugMonLow = GetBit(value[1], 6),
                 SnugMonHigh = GetBit(value[1], 7),
                 DynamicMinCurrent = GetBit(value[2], 0),
-                DynamicMacCurrent = GetBit(value[2], 1),
+                DynamicMaxCurrent = GetBit(value[2], 1),
                 LatentResult = GetBit(value[2], 2),
                 Reserved = new byte[10]
             };

--- a/src/OpenProtocolInterpreter/Converters/TighteningErrorStatusConverter.cs
+++ b/src/OpenProtocolInterpreter/Converters/TighteningErrorStatusConverter.cs
@@ -157,22 +157,22 @@ namespace OpenProtocolInterpreter.Converters
                 GradientMonitoringLow = GetBit(value[0], 5),
                 ReactionBarFailed = GetBit(value[0], 6),
                 SnugMax = GetBit(value[0], 7),
-                CycleAbort = GetBit(value[0], 8),
-                NeckingFailure = GetBit(value[0], 9),
-                EffectiveLoosening = GetBit(value[0], 10),
-                OverSpeed = GetBit(value[0], 11),
-                NoResidualTorque = GetBit(value[0], 12),
-                PositioningFail = GetBit(value[0], 13),
-                SnugMonLow = GetBit(value[0], 14),
-                SnugMonHigh = GetBit(value[0], 15),
-                DynamicMinCurrent = GetBit(value[0], 16),
-                DynamicMacCurrent = GetBit(value[0], 17),
-                LatentResult = GetBit(value[0], 18),
+                CycleAbort = GetBit(value[1], 0),
+                NeckingFailure = GetBit(value[1], 1),
+                EffectiveLoosening = GetBit(value[1], 2),
+                OverSpeed = GetBit(value[1], 3),
+                NoResidualTorque = GetBit(value[1], 4),
+                PositioningFail = GetBit(value[1], 5),
+                SnugMonLow = GetBit(value[1], 6),
+                SnugMonHigh = GetBit(value[1], 7),
+                DynamicMinCurrent = GetBit(value[2], 0),
+                DynamicMacCurrent = GetBit(value[2], 1),
+                LatentResult = GetBit(value[2], 2),
                 Reserved = new byte[10]
             };
 
             //set only 19 and 20 bytes to reserved
-            obj.Reserved[0] = SetByte(new bool[] { GetBit(value[0], 19), GetBit(value[0], 20), false, false, false, false, false, false });
+            obj.Reserved[0] = SetByte(new bool[] { GetBit(value[2], 3), GetBit(value[2], 4), false, false, false, false, false, false });
 
             return obj;
         }

--- a/src/OpenProtocolInterpreter/Tightening/TighteningErrorStatus.cs
+++ b/src/OpenProtocolInterpreter/Tightening/TighteningErrorStatus.cs
@@ -61,7 +61,7 @@
         public bool SnugMonLow { get; set; }
         public bool SnugMonHigh { get; set; }
         public bool DynamicMinCurrent { get; set; }
-        public bool DynamicMacCurrent { get; set; }
+        public bool DynamicMaxCurrent { get; set; }
         public bool LatentResult { get; set; }
 
         //Bit 19-31

--- a/src/OpenProtocolInterpreter/Tightening/TighteningErrorStatus.cs
+++ b/src/OpenProtocolInterpreter/Tightening/TighteningErrorStatus.cs
@@ -51,8 +51,20 @@
         public bool GradientMonitoringHigh { get; set; }
         public bool GradientMonitoringLow { get; set; }
         public bool ReactionBarFailed { get; set; }
+        public bool SnugMax { get; set; }
+        public bool CycleAbort { get; set; }
+        public bool NeckingFailure { get; set; }
+        public bool EffectiveLoosening { get; set; }
+        public bool OverSpeed { get; set; }
+        public bool NoResidualTorque { get; set; }
+        public bool PositioningFail { get; set; }
+        public bool SnugMonLow { get; set; }
+        public bool SnugMonHigh { get; set; }
+        public bool DynamicMinCurrent { get; set; }
+        public bool DynamicMacCurrent { get; set; }
+        public bool LatentResult { get; set; }
 
-        //Bit 6-31 
+        //Bit 19-31
         public byte[] Reserved { get; set; }
     }
 }


### PR DESCRIPTION
This PR is to add missing tightening error statuses 2 that became available for MID 0061 since Revision 6:
[OpenProtocol_Specification](https://github.com/Rickedb/OpenProtocolInterpreter/blob/master/docs/OpenProtocol_Specification.pdf)

The following statuses were added:
- SnugMax
- CycleAbort
- NeckingFailure
- EffectiveLoosening
- OverSpeed
- NoResidualTorque
- PositioningFail
- SnugMonLow
- SnugMonHigh
- DynamicMinCurrent
- DynamicMaxCurrent
- LatentResult

The relevant tests were updated as well.