### PR TITLE
SR 2.14 Project - Version 4.0.0

### DIFF
--- a/src/MIDTesters.Core/Alarm/TestMid0074.cs
+++ b/src/MIDTesters.Core/Alarm/TestMid0074.cs
@@ -9,18 +9,19 @@ namespace MIDTesters.Alarm
     public class TestMid0074 : MidTester
     {
         [TestMethod]
-        public void Mid0074AllRevisions()
+        public void Mid0074Revision1()
         {
             string pack = @"00240074001         E851";
             var mid = _midInterpreter.Parse<Mid0074>(pack);
 
             Assert.AreEqual(typeof(Mid0074), mid.GetType());
             Assert.IsNotNull(mid.ErrorCode);
+            Assert.AreEqual(4, mid.ErrorCode.Length);
             Assert.AreEqual(pack, mid.Pack());
         }
 
         [TestMethod]
-        public void Mid0074ByteAllRevisions()
+        public void Mid0074ByteRevision1()
         {
             string pack = @"00240074001         E851";
             byte[] bytes = GetAsciiBytes(pack);
@@ -28,6 +29,31 @@ namespace MIDTesters.Alarm
 
             Assert.AreEqual(typeof(Mid0074), mid.GetType());
             Assert.IsNotNull(mid.ErrorCode);
+            Assert.AreEqual(4, mid.ErrorCode.Length);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+        [TestMethod]
+        public void Mid0074Revision2()
+        {
+            string pack = @"00250074002         E8514";
+            var mid = _midInterpreter.Parse<Mid0074>(pack);
+
+            Assert.AreEqual(typeof(Mid0074), mid.GetType());
+            Assert.IsNotNull(mid.ErrorCode);
+            Assert.AreEqual(5, mid.ErrorCode.Length);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0074ByteRevision2()
+        {
+            string pack = @"00250074002         E8514";
+            byte[] bytes = GetAsciiBytes(pack);
+            var mid = _midInterpreter.Parse<Mid0074>(bytes);
+
+            Assert.AreEqual(typeof(Mid0074), mid.GetType());
+            Assert.IsNotNull(mid.ErrorCode);
+            Assert.AreEqual(5, mid.ErrorCode.Length);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters.Core/Communication/TestMid0001.cs
+++ b/src/MIDTesters.Core/Communication/TestMid0001.cs
@@ -7,29 +7,47 @@ namespace MIDTesters.Communication
     [TestClass]
     public class TestMid0001 : MidTester
     {
-        private readonly string _package;
-
-        public TestMid0001()
-        {
-            _package = "00200001003         ";
-        }
-
         [TestMethod]
         public void Mid0001AllRevisions()
         {
-            var mid = _midInterpreter.Parse(_package);
+            var package = "00200001003         ";
+            var mid = _midInterpreter.Parse(package);
 
             Assert.AreEqual(typeof(Mid0001), mid.GetType());
-            Assert.AreEqual(_package, mid.Pack());
+            Assert.AreEqual(package, mid.Pack());
         }
 
         [TestMethod]
         public void Mid0001AllByteRevisions()
         {
-            byte[] bytes = GetAsciiBytes(_package);
+            var package = "00200001003         ";
+            byte[] bytes = GetAsciiBytes(package);
             var mid = _midInterpreter.Parse(bytes);
 
             Assert.AreEqual(typeof(Mid0001), mid.GetType());
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0001Revision7()
+        {
+            var package = "00230001007         011";
+            var mid = _midInterpreter.Parse<Mid0001>(package);
+
+            Assert.AreEqual(typeof(Mid0001), mid.GetType());
+            Assert.IsNotNull(mid.OptionalKeepAlive);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0001ByteRevision7()
+        {
+            var package = "00230001007         011";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0001>(bytes);
+
+            Assert.AreEqual(typeof(Mid0001), mid.GetType());
+            Assert.IsNotNull(mid.OptionalKeepAlive);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters.Core/Job/TestMid0032.cs
+++ b/src/MIDTesters.Core/Job/TestMid0032.cs
@@ -76,5 +76,28 @@ namespace MIDTesters.Job
             Assert.IsNotNull(mid.JobId);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
+
+        [TestMethod]
+        public void Mid0032Revision4()
+        {
+            string package = "00240032004         0003";
+            var mid = _midInterpreter.Parse<Mid0032>(package);
+
+            Assert.AreEqual(typeof(Mid0032), mid.GetType());
+            Assert.IsNotNull(mid.JobId);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0032ByteRevision4()
+        {
+            string package = "00240032004         0003";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0032>(bytes);
+
+            Assert.AreEqual(typeof(Mid0032), mid.GetType());
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
     }
 }

--- a/src/MIDTesters.Core/MIDTesters.Core.csproj
+++ b/src/MIDTesters.Core/MIDTesters.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/MIDTesters.Core/ParameterSet/TestMid0013.cs
+++ b/src/MIDTesters.Core/ParameterSet/TestMid0013.cs
@@ -93,5 +93,52 @@ namespace MIDTesters.ParameterSet
             Assert.IsNotNull(mid.StartFinalAngle);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
+
+        [TestMethod]
+        public void Mid0013Revision5()
+        {
+            string pack = @"01410013005         0100102Airbag1                  03104030500120006001500070014000800360090072010004801102021112017854132001-05-29:12:34:33";
+            var mid = _midInterpreter.Parse<Mid0013>(pack);
+
+            Assert.AreEqual(typeof(Mid0013), mid.GetType());
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.RotationDirection);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.MinTorque);
+            Assert.IsNotNull(mid.MaxTorque);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.MinAngle);
+            Assert.IsNotNull(mid.MaxAngle);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.FirstTarget);
+            Assert.IsNotNull(mid.StartFinalAngle);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0013ByteRevision5()
+        {
+            string package = @"01410013005         0100102Airbag1                  03104030500120006001500070014000800360090072010004801102021112017854132001-05-29:12:34:33";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0013>(bytes);
+
+            Assert.AreEqual(typeof(Mid0013), mid.GetType());
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.RotationDirection);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.MinTorque);
+            Assert.IsNotNull(mid.MaxTorque);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.MinAngle);
+            Assert.IsNotNull(mid.MaxAngle);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.FirstTarget);
+            Assert.IsNotNull(mid.StartFinalAngle);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
     }
 }

--- a/src/MIDTesters.Core/Tool/TestMid0040.cs
+++ b/src/MIDTesters.Core/Tool/TestMid0040.cs
@@ -8,7 +8,7 @@ namespace MIDTesters.Tool
     public class TestMid0040 : MidTester
     {
         [TestMethod]
-        public void Mid0040AllRevisions()
+        public void Mid0040Revisions1To5()
         {
             string package = "00200040004         ";
             var mid = _midInterpreter.Parse(package);
@@ -18,13 +18,36 @@ namespace MIDTesters.Tool
         }
 
         [TestMethod]
-        public void Mid0040ByteAllRevisions()
+        public void Mid0040ByteRevisions1To5()
         {
             string package = "00200040004         ";
             byte[] bytes = GetAsciiBytes(package);
             var mid = _midInterpreter.Parse(bytes);
 
             Assert.AreEqual(typeof(Mid0040), mid.GetType());
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0040Revisions6And7()
+        {
+            string package = "00260040007         010001";
+            var mid = (Mid0040)_midInterpreter.Parse(package);
+
+            Assert.AreEqual(typeof(Mid0040), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0040ByteRevisions6And7()
+        {
+            string package = "00260040007         010001";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = (Mid0040)_midInterpreter.Parse(bytes);
+
+            Assert.AreEqual(typeof(Mid0040), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters.Core/Tool/TestMid0041.cs
+++ b/src/MIDTesters.Core/Tool/TestMid0041.cs
@@ -256,5 +256,137 @@ namespace MIDTesters.Tool
             Assert.IsNotNull(mid.ToolModel);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
+
+        [TestMethod]
+        public void Mid0041Revision6()
+        {
+            string package = "02360041006         01ABCDEFG-123456024294967295032017-12-01:20:12:4504GFEDCBA-1005002000062018-06-04:10:12:45074284967295081009551011111Version 1.0.0      120006001300123014004000150316Tool Model  17000118Tool Article Number           ";
+            var mid = _midInterpreter.Parse<Mid0041>(package);
+
+            Assert.AreEqual(typeof(Mid0041), mid.GetType());
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.ToolNumberOfTightenings);
+            Assert.IsNotNull(mid.LastCalibrationDate);
+            Assert.IsNotNull(mid.ControllerSerialNumber);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.LastServiceDate);
+            Assert.IsNotNull(mid.TighteningsSinceService);
+            Assert.IsNotNull(mid.ToolType);
+            Assert.IsNotNull(mid.MotorSize);
+            Assert.IsNotNull(mid.OpenEndData);
+            Assert.IsNotNull(mid.OpenEndData.UseOpenEnd);
+            Assert.IsNotNull(mid.OpenEndData.TighteningDirection);
+            Assert.IsNotNull(mid.OpenEndData.MotorRotation);
+            Assert.IsNotNull(mid.ControllerSoftwareVersion);
+            Assert.IsNotNull(mid.ToolMaxTorque);
+            Assert.IsNotNull(mid.GearRatio);
+            Assert.IsNotNull(mid.ToolFullSpeed);
+            Assert.IsNotNull(mid.PrimaryTool);
+            Assert.IsNotNull(mid.ToolModel);
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.ToolArticleNumber);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0041ByteRevision6()
+        {
+            string package = "02360041006         01ABCDEFG-123456024294967295032017-12-01:20:12:4504GFEDCBA-1005002000062018-06-04:10:12:45074284967295081009551011111Version 1.0.0      120006001300123014004000150316Tool Model  17000118Tool Article Number           ";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0041>(bytes);
+
+            Assert.AreEqual(typeof(Mid0041), mid.GetType());
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.ToolNumberOfTightenings);
+            Assert.IsNotNull(mid.LastCalibrationDate);
+            Assert.IsNotNull(mid.ControllerSerialNumber);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.LastServiceDate);
+            Assert.IsNotNull(mid.TighteningsSinceService);
+            Assert.IsNotNull(mid.ToolType);
+            Assert.IsNotNull(mid.MotorSize);
+            Assert.IsNotNull(mid.OpenEndData);
+            Assert.IsNotNull(mid.OpenEndData.UseOpenEnd);
+            Assert.IsNotNull(mid.OpenEndData.TighteningDirection);
+            Assert.IsNotNull(mid.OpenEndData.MotorRotation);
+            Assert.IsNotNull(mid.ControllerSoftwareVersion);
+            Assert.IsNotNull(mid.ToolMaxTorque);
+            Assert.IsNotNull(mid.GearRatio);
+            Assert.IsNotNull(mid.ToolFullSpeed);
+            Assert.IsNotNull(mid.PrimaryTool);
+            Assert.IsNotNull(mid.ToolModel);
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.ToolArticleNumber);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0041Revision7()
+        {
+            string package = "02600041007         01ABCDEFG-123456024294967295032017-12-01:20:12:4504GFEDCBA-1005002000062018-06-04:10:12:45074284967295081009551011111Version 1.0.0      120006001300123014004000150316Tool Model  17000118Tool Article Number           190010002003200021013000";
+            var mid = _midInterpreter.Parse<Mid0041>(package);
+
+            Assert.AreEqual(typeof(Mid0041), mid.GetType());
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.ToolNumberOfTightenings);
+            Assert.IsNotNull(mid.LastCalibrationDate);
+            Assert.IsNotNull(mid.ControllerSerialNumber);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.LastServiceDate);
+            Assert.IsNotNull(mid.TighteningsSinceService);
+            Assert.IsNotNull(mid.ToolType);
+            Assert.IsNotNull(mid.MotorSize);
+            Assert.IsNotNull(mid.OpenEndData);
+            Assert.IsNotNull(mid.OpenEndData.UseOpenEnd);
+            Assert.IsNotNull(mid.OpenEndData.TighteningDirection);
+            Assert.IsNotNull(mid.OpenEndData.MotorRotation);
+            Assert.IsNotNull(mid.ControllerSoftwareVersion);
+            Assert.IsNotNull(mid.ToolMaxTorque);
+            Assert.IsNotNull(mid.GearRatio);
+            Assert.IsNotNull(mid.ToolFullSpeed);
+            Assert.IsNotNull(mid.PrimaryTool);
+            Assert.IsNotNull(mid.ToolModel);
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.ToolArticleNumber);
+            Assert.IsNotNull(mid.RundownMinSpeed);
+            Assert.IsNotNull(mid.DownshiftMaxSpeed);
+            Assert.IsNotNull(mid.DownshiftMinSpeed);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0041ByteRevision7()
+        {
+            string package = "02600041007         01ABCDEFG-123456024294967295032017-12-01:20:12:4504GFEDCBA-1005002000062018-06-04:10:12:45074284967295081009551011111Version 1.0.0      120006001300123014004000150316Tool Model  17000118Tool Article Number           190010002003200021013000";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0041>(bytes);
+
+            Assert.AreEqual(typeof(Mid0041), mid.GetType());
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.ToolNumberOfTightenings);
+            Assert.IsNotNull(mid.LastCalibrationDate);
+            Assert.IsNotNull(mid.ControllerSerialNumber);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.LastServiceDate);
+            Assert.IsNotNull(mid.TighteningsSinceService);
+            Assert.IsNotNull(mid.ToolType);
+            Assert.IsNotNull(mid.MotorSize);
+            Assert.IsNotNull(mid.OpenEndData);
+            Assert.IsNotNull(mid.OpenEndData.UseOpenEnd);
+            Assert.IsNotNull(mid.OpenEndData.TighteningDirection);
+            Assert.IsNotNull(mid.OpenEndData.MotorRotation);
+            Assert.IsNotNull(mid.ControllerSoftwareVersion);
+            Assert.IsNotNull(mid.ToolMaxTorque);
+            Assert.IsNotNull(mid.GearRatio);
+            Assert.IsNotNull(mid.ToolFullSpeed);
+            Assert.IsNotNull(mid.PrimaryTool);
+            Assert.IsNotNull(mid.ToolModel);
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.ToolArticleNumber);
+            Assert.IsNotNull(mid.RundownMinSpeed);
+            Assert.IsNotNull(mid.DownshiftMaxSpeed);
+            Assert.IsNotNull(mid.DownshiftMinSpeed);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
     }
 }

--- a/src/MIDTesters.Core/Tool/TestMid0042.cs
+++ b/src/MIDTesters.Core/Tool/TestMid0042.cs
@@ -9,7 +9,7 @@ namespace MIDTesters.Tool
     public class TestMid0042 : MidTester
     {
         [TestMethod]
-        public void Mid0042AllRevisions()
+        public void Mid0042Revision1()
         {
             string package = "00200042            ";
             var mid = _midInterpreter.Parse(package);
@@ -19,13 +19,38 @@ namespace MIDTesters.Tool
         }
 
         [TestMethod]
-        public void Mid0042ByteAllRevisions()
+        public void Mid0042ByteRevision1()
         {
             string package = "00200042            ";
             byte[] bytes = GetAsciiBytes(package);
             var mid = _midInterpreter.Parse(bytes);
 
             Assert.AreEqual(typeof(Mid0042), mid.GetType());
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0042Revision2()
+        {
+            string package = "00300042002         0100420201";
+            var mid = _midInterpreter.Parse<Mid0042>(package);
+
+            Assert.AreEqual(typeof(Mid0042), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.DisableType);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0042ByteRevision2()
+        {
+            string package = "00300042002         0100420200";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0042>(bytes);
+
+            Assert.AreEqual(typeof(Mid0042), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.DisableType);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters.Core/Tool/TestMid0043.cs
+++ b/src/MIDTesters.Core/Tool/TestMid0043.cs
@@ -9,7 +9,7 @@ namespace MIDTesters.Tool
     public class TestMid0043 : MidTester
     {
         [TestMethod]
-        public void Mid0043AllRevisions()
+        public void Mid0043Revision1()
         {
             string package = "00200043            ";
             var mid = _midInterpreter.Parse(package);
@@ -19,13 +19,36 @@ namespace MIDTesters.Tool
         }
 
         [TestMethod]
-        public void Mid0043ByteAllRevisions()
+        public void Mid0043ByteRevision1()
         {
             string package = "00200043            ";
             byte[] bytes = GetAsciiBytes(package);
             var mid = _midInterpreter.Parse(bytes);
 
             Assert.AreEqual(typeof(Mid0043), mid.GetType());
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0043Revision2()
+        {
+            string package = "00260043002         010042";
+            var mid = _midInterpreter.Parse<Mid0043>(package);
+
+            Assert.AreEqual(typeof(Mid0043), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0043ByteRevision2()
+        {
+            string package = "00260043002         010032";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0043>(bytes);
+
+            Assert.AreEqual(typeof(Mid0043), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters.Core/Tool/TestMid0045.cs
+++ b/src/MIDTesters.Core/Tool/TestMid0045.cs
@@ -9,7 +9,7 @@ namespace MIDTesters.Tool
     public class TestMid0045 : MidTester
     {
         [TestMethod]
-        public void Mid0045AllRevisions()
+        public void Mid0045Revision1()
         {
             string package = "00310045            01402003000";
             var mid = _midInterpreter.Parse<Mid0045>(package);
@@ -21,7 +21,7 @@ namespace MIDTesters.Tool
         }
 
         [TestMethod]
-        public void Mid0045ByteAllRevisions()
+        public void Mid0045ByteRevision1()
         {
             string package = "00310045            01402003000";
             byte[] bytes = GetAsciiBytes(package);
@@ -30,6 +30,33 @@ namespace MIDTesters.Tool
             Assert.AreEqual(typeof(Mid0045), mid.GetType());
             Assert.IsNotNull(mid.CalibrationValueUnit);
             Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0045Revision2()
+        {
+            string package = "00350045002         014020030000301";
+            var mid = _midInterpreter.Parse<Mid0045>(package);
+
+            Assert.AreEqual(typeof(Mid0045), mid.GetType());
+            Assert.IsNotNull(mid.CalibrationValueUnit);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.ChannelNumber);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0045ByteRevision2()
+        {
+            string package = "00350045002         014020030000302";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0045>(bytes);
+
+            Assert.AreEqual(typeof(Mid0045), mid.GetType());
+            Assert.IsNotNull(mid.CalibrationValueUnit);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.ChannelNumber);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters/Alarm/TestMid0074.cs
+++ b/src/MIDTesters/Alarm/TestMid0074.cs
@@ -9,18 +9,19 @@ namespace MIDTesters.Alarm
     public class TestMid0074 : MidTester
     {
         [TestMethod]
-        public void Mid0074AllRevisions()
+        public void Mid0074Revision1()
         {
             string pack = @"00240074001         E851";
             var mid = _midInterpreter.Parse<Mid0074>(pack);
 
             Assert.AreEqual(typeof(Mid0074), mid.GetType());
             Assert.IsNotNull(mid.ErrorCode);
+            Assert.AreEqual(4, mid.ErrorCode.Length);
             Assert.AreEqual(pack, mid.Pack());
         }
 
         [TestMethod]
-        public void Mid0074ByteAllRevisions()
+        public void Mid0074ByteRevision1()
         {
             string pack = @"00240074001         E851";
             byte[] bytes = GetAsciiBytes(pack);
@@ -28,6 +29,31 @@ namespace MIDTesters.Alarm
 
             Assert.AreEqual(typeof(Mid0074), mid.GetType());
             Assert.IsNotNull(mid.ErrorCode);
+            Assert.AreEqual(4, mid.ErrorCode.Length);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+        [TestMethod]
+        public void Mid0074Revision2()
+        {
+            string pack = @"00250074002         E8514";
+            var mid = _midInterpreter.Parse<Mid0074>(pack);
+
+            Assert.AreEqual(typeof(Mid0074), mid.GetType());
+            Assert.IsNotNull(mid.ErrorCode);
+            Assert.AreEqual(5, mid.ErrorCode.Length);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0074ByteRevision2()
+        {
+            string pack = @"00250074002         E8514";
+            byte[] bytes = GetAsciiBytes(pack);
+            var mid = _midInterpreter.Parse<Mid0074>(bytes);
+
+            Assert.AreEqual(typeof(Mid0074), mid.GetType());
+            Assert.IsNotNull(mid.ErrorCode);
+            Assert.AreEqual(5, mid.ErrorCode.Length);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters/Communication/TestMid0001.cs
+++ b/src/MIDTesters/Communication/TestMid0001.cs
@@ -7,29 +7,47 @@ namespace MIDTesters.Communication
     [TestClass]
     public class TestMid0001 : MidTester
     {
-        private readonly string _package;
-
-        public TestMid0001()
-        {
-            _package = "00200001003         ";
-        }
-
         [TestMethod]
         public void Mid0001AllRevisions()
         {
-            var mid = _midInterpreter.Parse(_package);
+            var package = "00200001003         ";
+            var mid = _midInterpreter.Parse(package);
 
             Assert.AreEqual(typeof(Mid0001), mid.GetType());
-            Assert.AreEqual(_package, mid.Pack());
+            Assert.AreEqual(package, mid.Pack());
         }
 
         [TestMethod]
         public void Mid0001AllByteRevisions()
         {
-            byte[] bytes = GetAsciiBytes(_package);
+            var package = "00200001003         ";
+            byte[] bytes = GetAsciiBytes(package);
             var mid = _midInterpreter.Parse(bytes);
 
             Assert.AreEqual(typeof(Mid0001), mid.GetType());
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0001Revision7()
+        {
+            var package = "00230001007         011";
+            var mid = _midInterpreter.Parse<Mid0001>(package);
+
+            Assert.AreEqual(typeof(Mid0001), mid.GetType());
+            Assert.IsNotNull(mid.OptionalKeepAlive);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0001ByteRevision7()
+        {
+            var package = "00230001007         011";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0001>(bytes);
+
+            Assert.AreEqual(typeof(Mid0001), mid.GetType());
+            Assert.IsNotNull(mid.OptionalKeepAlive);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters/Job/TestMid0032.cs
+++ b/src/MIDTesters/Job/TestMid0032.cs
@@ -76,5 +76,28 @@ namespace MIDTesters.Job
             Assert.IsNotNull(mid.JobId);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
+
+        [TestMethod]
+        public void Mid0032Revision4()
+        {
+            string package = "00240032004         0003";
+            var mid = _midInterpreter.Parse<Mid0032>(package);
+
+            Assert.AreEqual(typeof(Mid0032), mid.GetType());
+            Assert.IsNotNull(mid.JobId);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0032ByteRevision4()
+        {
+            string package = "00240032004         0003";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0032>(bytes);
+
+            Assert.AreEqual(typeof(Mid0032), mid.GetType());
+            Assert.IsNotNull(mid.JobId);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
     }
 }

--- a/src/MIDTesters/ParameterSet/TestMid0013.cs
+++ b/src/MIDTesters/ParameterSet/TestMid0013.cs
@@ -93,5 +93,52 @@ namespace MIDTesters.ParameterSet
             Assert.IsNotNull(mid.StartFinalAngle);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
+
+        [TestMethod]
+        public void Mid0013Revision5()
+        {
+            string pack = @"01410013005         0100102Airbag1                  03104030500120006001500070014000800360090072010004801102021112017854132001-05-29:12:34:33";
+            var mid = _midInterpreter.Parse<Mid0013>(pack);
+
+            Assert.AreEqual(typeof(Mid0013), mid.GetType());
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.RotationDirection);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.MinTorque);
+            Assert.IsNotNull(mid.MaxTorque);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.MinAngle);
+            Assert.IsNotNull(mid.MaxAngle);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.FirstTarget);
+            Assert.IsNotNull(mid.StartFinalAngle);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.AreEqual(pack, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0013ByteRevision5()
+        {
+            string package = @"01410013005         0100102Airbag1                  03104030500120006001500070014000800360090072010004801102021112017854132001-05-29:12:34:33";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0013>(bytes);
+
+            Assert.AreEqual(typeof(Mid0013), mid.GetType());
+            Assert.IsNotNull(mid.ParameterSetId);
+            Assert.IsNotNull(mid.ParameterSetName);
+            Assert.IsNotNull(mid.RotationDirection);
+            Assert.IsNotNull(mid.BatchSize);
+            Assert.IsNotNull(mid.MinTorque);
+            Assert.IsNotNull(mid.MaxTorque);
+            Assert.IsNotNull(mid.TorqueFinalTarget);
+            Assert.IsNotNull(mid.MinAngle);
+            Assert.IsNotNull(mid.MaxAngle);
+            Assert.IsNotNull(mid.AngleFinalTarget);
+            Assert.IsNotNull(mid.FirstTarget);
+            Assert.IsNotNull(mid.StartFinalAngle);
+            Assert.IsNotNull(mid.LastChangeInParameterSet);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
     }
 }

--- a/src/MIDTesters/Tool/TestMid0040.cs
+++ b/src/MIDTesters/Tool/TestMid0040.cs
@@ -8,7 +8,7 @@ namespace MIDTesters.Tool
     public class TestMid0040 : MidTester
     {
         [TestMethod]
-        public void Mid0040AllRevisions()
+        public void Mid0040Revisions1To5()
         {
             string package = "00200040004         ";
             var mid = _midInterpreter.Parse(package);
@@ -18,13 +18,36 @@ namespace MIDTesters.Tool
         }
 
         [TestMethod]
-        public void Mid0040ByteAllRevisions()
+        public void Mid0040ByteRevisions1To5()
         {
             string package = "00200040004         ";
             byte[] bytes = GetAsciiBytes(package);
             var mid = _midInterpreter.Parse(bytes);
 
             Assert.AreEqual(typeof(Mid0040), mid.GetType());
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0040Revisions6And7()
+        {
+            string package = "00260040007         010001";
+            var mid = _midInterpreter.Parse<Mid0040>(package);
+
+            Assert.AreEqual(typeof(Mid0040), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0040ByteRevisions6And7()
+        {
+            string package = "00260040007         010001";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0040>(bytes);
+
+            Assert.AreEqual(typeof(Mid0040), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters/Tool/TestMid0041.cs
+++ b/src/MIDTesters/Tool/TestMid0041.cs
@@ -256,5 +256,137 @@ namespace MIDTesters.Tool
             Assert.IsNotNull(mid.ToolModel);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
+
+        [TestMethod]
+        public void Mid0041Revision6()
+        {
+            string package = "02360041006         01ABCDEFG-123456024294967295032017-12-01:20:12:4504GFEDCBA-1005002000062018-06-04:10:12:45074284967295081009551011111Version 1.0.0      120006001300123014004000150316Tool Model  17000118Tool Article Number           ";
+            var mid = _midInterpreter.Parse<Mid0041>(package);
+
+            Assert.AreEqual(typeof(Mid0041), mid.GetType());
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.ToolNumberOfTightenings);
+            Assert.IsNotNull(mid.LastCalibrationDate);
+            Assert.IsNotNull(mid.ControllerSerialNumber);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.LastServiceDate);
+            Assert.IsNotNull(mid.TighteningsSinceService);
+            Assert.IsNotNull(mid.ToolType);
+            Assert.IsNotNull(mid.MotorSize);
+            Assert.IsNotNull(mid.OpenEndData);
+            Assert.IsNotNull(mid.OpenEndData.UseOpenEnd);
+            Assert.IsNotNull(mid.OpenEndData.TighteningDirection);
+            Assert.IsNotNull(mid.OpenEndData.MotorRotation);
+            Assert.IsNotNull(mid.ControllerSoftwareVersion);
+            Assert.IsNotNull(mid.ToolMaxTorque);
+            Assert.IsNotNull(mid.GearRatio);
+            Assert.IsNotNull(mid.ToolFullSpeed);
+            Assert.IsNotNull(mid.PrimaryTool);
+            Assert.IsNotNull(mid.ToolModel);
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.ToolArticleNumber);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0041ByteRevision6()
+        {
+            string package = "02360041006         01ABCDEFG-123456024294967295032017-12-01:20:12:4504GFEDCBA-1005002000062018-06-04:10:12:45074284967295081009551011111Version 1.0.0      120006001300123014004000150316Tool Model  17000118Tool Article Number           ";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0041>(bytes);
+
+            Assert.AreEqual(typeof(Mid0041), mid.GetType());
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.ToolNumberOfTightenings);
+            Assert.IsNotNull(mid.LastCalibrationDate);
+            Assert.IsNotNull(mid.ControllerSerialNumber);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.LastServiceDate);
+            Assert.IsNotNull(mid.TighteningsSinceService);
+            Assert.IsNotNull(mid.ToolType);
+            Assert.IsNotNull(mid.MotorSize);
+            Assert.IsNotNull(mid.OpenEndData);
+            Assert.IsNotNull(mid.OpenEndData.UseOpenEnd);
+            Assert.IsNotNull(mid.OpenEndData.TighteningDirection);
+            Assert.IsNotNull(mid.OpenEndData.MotorRotation);
+            Assert.IsNotNull(mid.ControllerSoftwareVersion);
+            Assert.IsNotNull(mid.ToolMaxTorque);
+            Assert.IsNotNull(mid.GearRatio);
+            Assert.IsNotNull(mid.ToolFullSpeed);
+            Assert.IsNotNull(mid.PrimaryTool);
+            Assert.IsNotNull(mid.ToolModel);
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.ToolArticleNumber);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0041Revision7()
+        {
+            string package = "02600041007         01ABCDEFG-123456024294967295032017-12-01:20:12:4504GFEDCBA-1005002000062018-06-04:10:12:45074284967295081009551011111Version 1.0.0      120006001300123014004000150316Tool Model  17000118Tool Article Number           190010002003200021013000";
+            var mid = _midInterpreter.Parse<Mid0041>(package);
+
+            Assert.AreEqual(typeof(Mid0041), mid.GetType());
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.ToolNumberOfTightenings);
+            Assert.IsNotNull(mid.LastCalibrationDate);
+            Assert.IsNotNull(mid.ControllerSerialNumber);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.LastServiceDate);
+            Assert.IsNotNull(mid.TighteningsSinceService);
+            Assert.IsNotNull(mid.ToolType);
+            Assert.IsNotNull(mid.MotorSize);
+            Assert.IsNotNull(mid.OpenEndData);
+            Assert.IsNotNull(mid.OpenEndData.UseOpenEnd);
+            Assert.IsNotNull(mid.OpenEndData.TighteningDirection);
+            Assert.IsNotNull(mid.OpenEndData.MotorRotation);
+            Assert.IsNotNull(mid.ControllerSoftwareVersion);
+            Assert.IsNotNull(mid.ToolMaxTorque);
+            Assert.IsNotNull(mid.GearRatio);
+            Assert.IsNotNull(mid.ToolFullSpeed);
+            Assert.IsNotNull(mid.PrimaryTool);
+            Assert.IsNotNull(mid.ToolModel);
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.ToolArticleNumber);
+            Assert.IsNotNull(mid.RundownMinSpeed);
+            Assert.IsNotNull(mid.DownshiftMaxSpeed);
+            Assert.IsNotNull(mid.DownshiftMinSpeed);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0041ByteRevision7()
+        {
+            string package = "02600041007         01ABCDEFG-123456024294967295032017-12-01:20:12:4504GFEDCBA-1005002000062018-06-04:10:12:45074284967295081009551011111Version 1.0.0      120006001300123014004000150316Tool Model  17000118Tool Article Number           190010002003200021013000";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0041>(bytes);
+
+            Assert.AreEqual(typeof(Mid0041), mid.GetType());
+            Assert.IsNotNull(mid.ToolSerialNumber);
+            Assert.IsNotNull(mid.ToolNumberOfTightenings);
+            Assert.IsNotNull(mid.LastCalibrationDate);
+            Assert.IsNotNull(mid.ControllerSerialNumber);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.LastServiceDate);
+            Assert.IsNotNull(mid.TighteningsSinceService);
+            Assert.IsNotNull(mid.ToolType);
+            Assert.IsNotNull(mid.MotorSize);
+            Assert.IsNotNull(mid.OpenEndData);
+            Assert.IsNotNull(mid.OpenEndData.UseOpenEnd);
+            Assert.IsNotNull(mid.OpenEndData.TighteningDirection);
+            Assert.IsNotNull(mid.OpenEndData.MotorRotation);
+            Assert.IsNotNull(mid.ControllerSoftwareVersion);
+            Assert.IsNotNull(mid.ToolMaxTorque);
+            Assert.IsNotNull(mid.GearRatio);
+            Assert.IsNotNull(mid.ToolFullSpeed);
+            Assert.IsNotNull(mid.PrimaryTool);
+            Assert.IsNotNull(mid.ToolModel);
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.ToolArticleNumber);
+            Assert.IsNotNull(mid.RundownMinSpeed);
+            Assert.IsNotNull(mid.DownshiftMaxSpeed);
+            Assert.IsNotNull(mid.DownshiftMinSpeed);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
     }
 }

--- a/src/MIDTesters/Tool/TestMid0042.cs
+++ b/src/MIDTesters/Tool/TestMid0042.cs
@@ -9,7 +9,7 @@ namespace MIDTesters.Tool
     public class TestMid0042 : MidTester
     {
         [TestMethod]
-        public void Mid0042AllRevisions()
+        public void Mid0042Revision1()
         {
             string package = "00200042            ";
             var mid = _midInterpreter.Parse(package);
@@ -19,13 +19,38 @@ namespace MIDTesters.Tool
         }
 
         [TestMethod]
-        public void Mid0042ByteAllRevisions()
+        public void Mid0042ByteRevision1()
         {
             string package = "00200042            ";
             byte[] bytes = GetAsciiBytes(package);
             var mid = _midInterpreter.Parse(bytes);
 
             Assert.AreEqual(typeof(Mid0042), mid.GetType());
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0042Revision2()
+        {
+            string package = "00300042002         0100420201";
+            var mid = _midInterpreter.Parse<Mid0042>(package);
+
+            Assert.AreEqual(typeof(Mid0042), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.DisableType);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0042ByteRevision2()
+        {
+            string package = "00300042002         0100420200";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0042>(bytes);
+
+            Assert.AreEqual(typeof(Mid0042), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.IsNotNull(mid.DisableType);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters/Tool/TestMid0043.cs
+++ b/src/MIDTesters/Tool/TestMid0043.cs
@@ -9,7 +9,7 @@ namespace MIDTesters.Tool
     public class TestMid0043 : MidTester
     {
         [TestMethod]
-        public void Mid0043AllRevisions()
+        public void Mid0043Revision1()
         {
             string package = "00200043            ";
             var mid = _midInterpreter.Parse(package);
@@ -19,13 +19,36 @@ namespace MIDTesters.Tool
         }
 
         [TestMethod]
-        public void Mid0043ByteAllRevisions()
+        public void Mid0043ByteRevision1()
         {
             string package = "00200043            ";
             byte[] bytes = GetAsciiBytes(package);
             var mid = _midInterpreter.Parse(bytes);
 
             Assert.AreEqual(typeof(Mid0043), mid.GetType());
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0043Revision2()
+        {
+            string package = "00260043002         010042";
+            var mid = _midInterpreter.Parse<Mid0043>(package);
+
+            Assert.AreEqual(typeof(Mid0043), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0043ByteRevision2()
+        {
+            string package = "00260043002         010032";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0043>(bytes);
+
+            Assert.AreEqual(typeof(Mid0043), mid.GetType());
+            Assert.IsNotNull(mid.ToolNumber);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/MIDTesters/Tool/TestMid0045.cs
+++ b/src/MIDTesters/Tool/TestMid0045.cs
@@ -9,7 +9,7 @@ namespace MIDTesters.Tool
     public class TestMid0045 : MidTester
     {
         [TestMethod]
-        public void Mid0045AllRevisions()
+        public void Mid0045Revision1()
         {
             string package = "00310045            01402003000";
             var mid = _midInterpreter.Parse<Mid0045>(package);
@@ -21,7 +21,7 @@ namespace MIDTesters.Tool
         }
 
         [TestMethod]
-        public void Mid0045ByteAllRevisions()
+        public void Mid0045ByteRevision1()
         {
             string package = "00310045            01402003000";
             byte[] bytes = GetAsciiBytes(package);
@@ -30,6 +30,33 @@ namespace MIDTesters.Tool
             Assert.AreEqual(typeof(Mid0045), mid.GetType());
             Assert.IsNotNull(mid.CalibrationValueUnit);
             Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
+        }
+
+        [TestMethod]
+        public void Mid0045Revision2()
+        {
+            string package = "00350045002         014020030000301";
+            var mid = _midInterpreter.Parse<Mid0045>(package);
+
+            Assert.AreEqual(typeof(Mid0045), mid.GetType());
+            Assert.IsNotNull(mid.CalibrationValueUnit);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.ChannelNumber);
+            Assert.AreEqual(package, mid.Pack());
+        }
+
+        [TestMethod]
+        public void Mid0045ByteRevision2()
+        {
+            string package = "00350045002         014020030000302";
+            byte[] bytes = GetAsciiBytes(package);
+            var mid = _midInterpreter.Parse<Mid0045>(bytes);
+
+            Assert.AreEqual(typeof(Mid0045), mid.GetType());
+            Assert.IsNotNull(mid.CalibrationValueUnit);
+            Assert.IsNotNull(mid.CalibrationValue);
+            Assert.IsNotNull(mid.ChannelNumber);
             Assert.IsTrue(mid.PackBytes().SequenceEqual(bytes));
         }
     }

--- a/src/OpenProtocolInterpreter/Alarm/Mid0074.cs
+++ b/src/OpenProtocolInterpreter/Alarm/Mid0074.cs
@@ -16,8 +16,8 @@ namespace OpenProtocolInterpreter.Alarm
 
         public string ErrorCode
         {
-            get => GetField(1,(int)DataFields.ERROR_CODE).Value;
-            set => GetField(1,(int)DataFields.ERROR_CODE).SetValue(value);
+            get => GetField(1, (int)DataFields.ERROR_CODE).Value;
+            set => GetField(1, (int)DataFields.ERROR_CODE).SetValue(value);
         }
 
         public Mid0074() : this(LAST_REVISION)
@@ -25,11 +25,28 @@ namespace OpenProtocolInterpreter.Alarm
 
         }
 
-        public Mid0074(int revision = LAST_REVISION) : base(MID, revision) { }
+        public Mid0074(int revision = LAST_REVISION) : base(MID, revision)
+        {
+
+        }
 
         public Mid0074(string errorCode, int revision = LAST_REVISION) : this(revision)
         {
             ErrorCode = errorCode;
+        }
+
+        public override string Pack()
+        {
+            RevisionsByFields[1][(int)DataFields.ERROR_CODE].Size = HeaderData.Revision == 1 ? 4 : 5;
+            return base.Pack();
+        }
+
+        public override Mid Parse(string package)
+        {
+            HeaderData = ProcessHeader(package);
+            RevisionsByFields[1][(int)DataFields.ERROR_CODE].Size = HeaderData.Revision == 1 ? 4 : 5;
+            ProcessDataFields(package);
+            return this;
         }
 
         protected override Dictionary<int, List<DataField>> RegisterDatafields()

--- a/src/OpenProtocolInterpreter/Communication/Mid0001.cs
+++ b/src/OpenProtocolInterpreter/Communication/Mid0001.cs
@@ -1,4 +1,7 @@
-﻿namespace OpenProtocolInterpreter.Communication
+﻿using OpenProtocolInterpreter.Converters;
+using System.Collections.Generic;
+
+namespace OpenProtocolInterpreter.Communication
 {
     /// <summary>
     /// Application communication start
@@ -8,14 +11,48 @@
     /// </summary>
     public class Mid0001 : Mid, ICommunication, IIntegrator
     {
-        private const int LAST_REVISION = 5;
+        private readonly IValueConverter<bool> _boolConverter;
+        private const int LAST_REVISION = 7;
         public const int MID = 1;
+
+        public bool OptionalKeepAlive
+        {
+            get => GetField(7, (int)DataFields.USE_KEEPALIVE).GetValue(_boolConverter.Convert);
+            set => GetField(7, (int)DataFields.USE_KEEPALIVE).SetValue(_boolConverter.Convert, value);
+        }
 
         public Mid0001() : this(LAST_REVISION)
         {
 
         }
 
-        public Mid0001(int revision = LAST_REVISION) : base(MID, revision) { }
+        public Mid0001(int revision = 6) : base(MID, revision)
+        {
+            _boolConverter = new BoolConverter();
+        }
+
+        public Mid0001(bool optionalKeepAlive, int revision = 7) : this(revision)
+        {
+            OptionalKeepAlive = optionalKeepAlive;
+        }
+
+        protected override Dictionary<int, List<DataField>> RegisterDatafields()
+        {
+            return new Dictionary<int, List<DataField>>()
+            {
+                {
+                    7, new List<DataField>()
+                            {
+                                new DataField((int)DataFields.USE_KEEPALIVE, 20, 1)
+                            }
+                }
+            };
+        }
+
+        public enum DataFields
+        {
+            //Rev 7
+            USE_KEEPALIVE
+        }
     }
 }

--- a/src/OpenProtocolInterpreter/Converters/AdvancedJobListConverter.cs
+++ b/src/OpenProtocolInterpreter/Converters/AdvancedJobListConverter.cs
@@ -6,7 +6,6 @@ namespace OpenProtocolInterpreter.Converters
     public class AdvancedJobListConverter : AsciiConverter<IEnumerable<AdvancedJob>>
     {
         private readonly IValueConverter<int> _intConverter;
-        private readonly IValueConverter<bool> _boolConverter|;
         private readonly int _revision;
 
         public AdvancedJobListConverter(IValueConverter<int> intConverter, int revision)

--- a/src/OpenProtocolInterpreter/Converters/AdvancedJobListConverter.cs
+++ b/src/OpenProtocolInterpreter/Converters/AdvancedJobListConverter.cs
@@ -6,33 +6,48 @@ namespace OpenProtocolInterpreter.Converters
     public class AdvancedJobListConverter : AsciiConverter<IEnumerable<AdvancedJob>>
     {
         private readonly IValueConverter<int> _intConverter;
-        private readonly IValueConverter<bool> _boolConverter;
+        private readonly IValueConverter<bool> _boolConverter|;
         private readonly int _revision;
 
-        public AdvancedJobListConverter(IValueConverter<int> intConverter, IValueConverter<bool> boolConverter, int revision)
+        public AdvancedJobListConverter(IValueConverter<int> intConverter, int revision)
         {
             _intConverter = intConverter;
-            _boolConverter = boolConverter;
             _revision = revision;
         }
 
         public override string Convert(IEnumerable<AdvancedJob> value)
         {
-            List<string> advancedJobsList = new List<string>();
+            var advancedJobsList = new List<string>();
 
-            foreach(var job in value)
+            foreach (var job in value)
             {
-                List<string> fields = new List<string>
+                var fields = new List<string>
                 {
                     _intConverter.Convert('0', 2, DataField.PaddingOrientations.LEFT_PADDED, job.ChannelId),
                     _intConverter.Convert('0', 3, DataField.PaddingOrientations.LEFT_PADDED, job.ProgramId),
-                    _boolConverter.Convert(job.AutoSelect),
+                    _intConverter.Convert((int)job.AutoSelect),
                     _intConverter.Convert('0', 2, DataField.PaddingOrientations.LEFT_PADDED, job.BatchSize),
                     _intConverter.Convert('0', 2, DataField.PaddingOrientations.LEFT_PADDED, job.MaxCoherentNok)
                 };
 
-                if (_revision == 999)
+                if (_revision > 1)
+                {
                     fields.Add(_intConverter.Convert('0', 2, DataField.PaddingOrientations.LEFT_PADDED, job.BatchCounter));
+                    if (_revision != 999)
+                    {
+                        fields.Add(_intConverter.Convert('0', 4, DataField.PaddingOrientations.LEFT_PADDED, job.IdentifierNumber));
+                        fields.Add(GetPadded(' ', 25, DataField.PaddingOrientations.RIGHT_PADDED, job.JobStepName));
+                        fields.Add(_intConverter.Convert('0', 2, DataField.PaddingOrientations.LEFT_PADDED, job.JobStepType));
+                        if (_revision == 3)
+                        {
+                            fields.Add(_intConverter.Convert((int)job.ToolLoosening));
+                            fields.Add(_intConverter.Convert((int)job.JobBatchMode));
+                            fields.Add(_intConverter.Convert((int)job.BatchStatusAtIncrement));
+                            fields.Add(_intConverter.Convert((int)job.DecrementBatchAfterLoosening));
+                            fields.Add(_intConverter.Convert((int)job.CurrentBatchStatus));
+                        }
+                    }
+                }
                 advancedJobsList.Add(string.Join(":", fields));
             }
 
@@ -44,18 +59,38 @@ namespace OpenProtocolInterpreter.Converters
         public override IEnumerable<AdvancedJob> Convert(string value)
         {
             var list = value.Split(';');
-            foreach(var advancedJob in list)
+            foreach (var advancedJob in list)
             {
                 var fields = advancedJob.Split(':');
-                yield return new AdvancedJob()
+                var obj = new AdvancedJob()
                 {
                     ChannelId = _intConverter.Convert(fields[0]),
                     ProgramId = _intConverter.Convert(fields[1]),
-                    AutoSelect = _boolConverter.Convert(fields[2]),
+                    AutoSelect = (AutoSelect)_intConverter.Convert(fields[2]),
                     BatchSize = _intConverter.Convert(fields[3]),
-                    MaxCoherentNok = _intConverter.Convert(fields[4]),
-                    BatchCounter = _revision == 999 ? _intConverter.Convert(fields[5]) : 0
+                    MaxCoherentNok = _intConverter.Convert(fields[4])
                 };
+
+                if (_revision > 1)
+                {
+                    obj.BatchCounter = _intConverter.Convert(fields[5]);
+                    if (_revision != 999)
+                    {
+                        obj.IdentifierNumber = _intConverter.Convert(fields[6]);
+                        obj.JobStepName = fields[7];
+                        obj.JobStepType = _intConverter.Convert(fields[8]);
+                        if (_revision == 3)
+                        {
+                            obj.ToolLoosening = (ToolLoosening)_intConverter.Convert(fields[9]);
+                            obj.JobBatchMode = (BatchMode)_intConverter.Convert(fields[10]);
+                            obj.BatchStatusAtIncrement = (BatchStatusAtIncrement)_intConverter.Convert(fields[11]);
+                            obj.DecrementBatchAfterLoosening = (DecrementBatchAfterLoosening)_intConverter.Convert(fields[12]);
+                            obj.CurrentBatchStatus = (CurrentBatchStatus)_intConverter.Convert(fields[13]);
+                        }
+                    }
+                }
+
+                yield return obj;
             }
         }
     }

--- a/src/OpenProtocolInterpreter/Converters/SpindleOrPressStatusListConverter.cs
+++ b/src/OpenProtocolInterpreter/Converters/SpindleOrPressStatusListConverter.cs
@@ -21,7 +21,7 @@ namespace OpenProtocolInterpreter.Converters
         {
             for (int i = 0; i < value.Length; i += 18)
             {
-                var spindleValue = value.Substring(i * 18, 18);
+                var spindleValue = value.Substring(i, 18);
                 yield return new SpindleOrPressStatus()
                 {
                     SpindleOrPressNumber = _intConverter.Convert(spindleValue.Substring(0, 2)),

--- a/src/OpenProtocolInterpreter/Enums/AutoSelect.cs
+++ b/src/OpenProtocolInterpreter/Enums/AutoSelect.cs
@@ -1,0 +1,14 @@
+﻿namespace OpenProtocolInterpreter
+{
+    /// <summary>
+    /// Auto Select. Used in <see cref="Job.Advanced.Mid0140"/> in <see cref="Job.Advanced.AdvancedJob"/> .
+    /// </summary>
+    public enum AutoSelect
+    {
+        NONE = 0,
+        AUTO_NEXT_CHANGE = 1,
+        IO = 2,
+        FIELDBUS = 6,
+        SOCKET_TRAY = 8
+    }
+}

--- a/src/OpenProtocolInterpreter/Enums/BatchStatusAtIncrement.cs
+++ b/src/OpenProtocolInterpreter/Enums/BatchStatusAtIncrement.cs
@@ -1,0 +1,11 @@
+﻿namespace OpenProtocolInterpreter
+{
+    /// /// <summary>
+    /// Batch Status at Increment. Used in <see cref="Job.Advanced.Mid0140"/> in <see cref="Job.Advanced.AdvancedJob"/> .
+    /// </summary>
+    public enum BatchStatusAtIncrement
+    {
+        OK = 0,
+        NOK = 1
+    }
+}

--- a/src/OpenProtocolInterpreter/Enums/CalibrationUnit.cs
+++ b/src/OpenProtocolInterpreter/Enums/CalibrationUnit.cs
@@ -7,8 +7,11 @@
     {
         NM = 1,
         LBF_FT = 2,
-        LBF_LN = 3,
+        LBF_IN = 3,
         KPM = 4,
-        NCM = 5
+        KGF_CM = 5,
+        OZF_IN = 6,
+        PERCENTAGE = 7,
+        NCM = 8
     }
 }

--- a/src/OpenProtocolInterpreter/Enums/CurrentBatchStatus.cs
+++ b/src/OpenProtocolInterpreter/Enums/CurrentBatchStatus.cs
@@ -1,0 +1,12 @@
+﻿namespace OpenProtocolInterpreter
+{
+    /// <summary>
+    /// Current Batch Status. Used in <see cref="Job.Advanced.Mid0140"/> in <see cref="Job.Advanced.AdvancedJob"/>.
+    /// </summary>
+    public enum CurrentBatchStatus
+    {
+        NOT_STARTED = 0,
+        OK = 1,
+        NOK = 2
+    }
+}

--- a/src/OpenProtocolInterpreter/Enums/DecrementBatchAfterLoosening.cs
+++ b/src/OpenProtocolInterpreter/Enums/DecrementBatchAfterLoosening.cs
@@ -1,0 +1,12 @@
+﻿namespace OpenProtocolInterpreter
+{
+    /// /// <summary>
+    /// Decrement batch after loosening/OK tightening. Used in <see cref="Job.Advanced.Mid0140"/> in <see cref="Job.Advanced.AdvancedJob"/> .
+    /// </summary>
+    public enum DecrementBatchAfterLoosening
+    {
+        NEVER = 0,
+        ALWAYS = 1,
+        AFTER_OK = 2
+    }
+}

--- a/src/OpenProtocolInterpreter/Enums/DigitalInputNumber.cs
+++ b/src/OpenProtocolInterpreter/Enums/DigitalInputNumber.cs
@@ -41,6 +41,7 @@
         FIELDBUS_DIGIN_4 = 35,
         FLASH_TOOL_GREEN_LIGHT = 36,
 
+        MANUAL_MODE = 43,
         PARAMETER_SET_SELECT_BIT_4 = 45,
         PARAMETER_SET_SELECT_BIT_5 = 46,
         PARAMETER_SET_SELECT_BIT_6 = 47,
@@ -118,6 +119,11 @@
         XML_EMERGENCY_MODE = 135,
         MFU_TEST = 136,
         TOOL_IN_PARK_POSITION = 137,
+        ENABLE_OPERATION = 138,
+        STOP_TIGHTENING = 139,
+        START_LOOSENING_PULSE = 140,
+
+        /* 141-149 => Free to use (how to handle?) */
 
         PULSOR_TOOL_ENABLE = 150,
         PERFORM_AIR_HOSE_TEST = 151,

--- a/src/OpenProtocolInterpreter/Enums/DisableType.cs
+++ b/src/OpenProtocolInterpreter/Enums/DisableType.cs
@@ -1,0 +1,25 @@
+﻿namespace OpenProtocolInterpreter
+{
+    /// <summary>
+    /// Disable types. Used in <see cref="Tool.Mid0042"/>.
+    /// </summary>
+    public enum DisableType
+    {
+        /// <summary>
+        /// This is the same function as the revision 1 functionality. The tool is locked and cannot be started.
+        /// </summary>
+        DISABLE = 0,
+        /// <summary>
+        /// Will not run in the next tightening but will be included in the final result with status NOK
+        /// </summary>
+        INHIBIT_NOK = 1,
+        /// <summary>
+        /// ill not run in the next tightening but will be included in the final result with status OK
+        /// </summary>
+        INHIBIT_OK = 2,
+        /// <summary>
+        /// Will not run in the next tightening and will not be included in the final result
+        /// </summary>
+        INHIBIT_NO_RESULT = 3
+    }
+}

--- a/src/OpenProtocolInterpreter/Enums/RelayNumber.cs
+++ b/src/OpenProtocolInterpreter/Enums/RelayNumber.cs
@@ -21,6 +21,7 @@
         JOB_NOK = 13,
         JOB_RUNNING = 14,
 
+        TOOL_HEALTH_OK = 17,
         POWER_FOCUS_READY = 18,
         TOOL_READY = 19,
         TOOL_START_SWITCH = 20,

--- a/src/OpenProtocolInterpreter/Enums/RelayNumber.cs
+++ b/src/OpenProtocolInterpreter/Enums/RelayNumber.cs
@@ -56,6 +56,7 @@
         TOOL_RED_LIGHT = 52,
         TOOL_GREEN_LIGHT = 53,
         TOOL_YELLOW_LIGHT = 54,
+
         RUNNING_PSET_BIT_4 = 59,
         RUNNING_PSET_BIT_5 = 60,
         RUNNING_PSET_BIT_6 = 61,
@@ -206,6 +207,49 @@
 
         MIDDLE_COURSE_TRIGGER_ACTIVE = 351,
         FRONT_TRIGGER_ACTIVE = 352,
-        REVERSE_TRIGGER_ACTIVE = 353
+        REVERSE_TRIGGER_ACTIVE = 353,
+        RUNNING_JOB_BIT_9 = 354,
+        TOOL_UNLOCKED = 355,
+        /// <summary>
+        /// Indicates that the connection to the Atlas Copco license server has been lost or the synchronization has failed. 
+        /// The signal is cleared when the License manager synchronization has been done successfully
+        /// </summary>
+        LICENSE_SERVER_CONNECTION_LOST = 356,
+        /// <summary>
+        /// Tightening not disabled by external source
+        /// </summary>
+        TIGHTENING_EXTERNALLY_ENABLED = 357,
+        /// <summary>
+        /// Tightening disabled by external source
+        /// </summary>
+        TIGHTENING_EXTERNALLY_DISABLED = 358,
+        /// <summary>
+        /// Loosening not disabled by external source
+        /// </summary>
+        LOOSENING_EXTERNALLY_ENABLED = 359,
+        /// <summary>
+        /// Loosening disabled by external source
+        /// </summary>
+        LOOSENING_EXTERNALLY_DISABLED = 360,
+        /// <summary>
+        /// Multistep tightening program has ended, torque has fallen below Program end torque configured.
+        /// </summary>
+        PROGRAM_END = 361,
+        /// <summary>
+        /// Oil level supervision configured in the tool maintenance to remind the users when it is time to fill up oil in a pulse tool.
+        /// </summary>
+        PULSE_TOOL_ALARM_OIL_LEVEL_EMPTY = 362,
+        /// <summary>
+        /// Indicates high tightening time resulting in NOK tightening
+        /// </summary>
+        TIGHTENING_TIME_HIGH = 363,
+        /// <summary>
+        /// Indicates low tightening time resulting in NOK tightening
+        /// </summary>
+        TIGHTENING_TIME_LOW = 364,
+        /// <summary>
+        /// Output signal tracking the function button state. The signal is set when the function button is pressed and is cleared when the function button is released.
+        /// </summary>
+        TOOL_FUNCTION_BUTTON_PRESSED = 365
     }
 }

--- a/src/OpenProtocolInterpreter/Enums/ToolType.cs
+++ b/src/OpenProtocolInterpreter/Enums/ToolType.cs
@@ -19,6 +19,24 @@
         QST_TOOL = 11,
         STT_TOOL = 12,
         ST_WRENCH = 13,
-        ES_TOOL = 14
+        ES_TOOL = 14,
+        ESB = 15,
+        SB = 16,
+        SB_PLUS = 17,
+        PST_TOOL = 18,
+        STR_TOOL = 19,
+        ETD_M = 20,
+        ETD_MC = 21,
+        ETD_MT = 22,
+        QMC = 23,
+        QMT = 24,
+        BCV_RE = 25,
+        BCP_REW = 26,
+        E_LIT = 27,
+        ISB = 28,
+        ITB = 29,
+        QSHIELD_C = 30,
+        DELTA_WRENCH = 31,
+        STR_WRENCH = 32
     }
 }

--- a/src/OpenProtocolInterpreter/Enums/TorqueValuesUnit.cs
+++ b/src/OpenProtocolInterpreter/Enums/TorqueValuesUnit.cs
@@ -9,7 +9,7 @@ namespace OpenProtocolInterpreter
     {
         NM = 1,
         LBF_FT = 2,
-        LBF_LN = 3,
+        LBF_IN = 3,
         KPM = 4,
         KGF_CM = 5,
         OZF_IN = 6,

--- a/src/OpenProtocolInterpreter/Enums/TorqueValuesUnit.cs
+++ b/src/OpenProtocolInterpreter/Enums/TorqueValuesUnit.cs
@@ -1,4 +1,6 @@
-﻿namespace OpenProtocolInterpreter
+﻿using System;
+
+namespace OpenProtocolInterpreter
 {
     /// <summary>
     /// Torque values unit. Used in <see cref="Tightening.Mid0061"/> and <see cref="Tightening.Mid0065"/>.
@@ -11,6 +13,7 @@
         KPM = 4,
         KGF_CM = 5,
         OZF_IN = 6,
+        [Obsolete("Percentage of torque was marked as obsolete since Specification 2.10.0")]
         PERCENTAGE = 7,
         NCM = 8
     }

--- a/src/OpenProtocolInterpreter/Job/Advanced/AdvancedJob.cs
+++ b/src/OpenProtocolInterpreter/Job/Advanced/AdvancedJob.cs
@@ -7,9 +7,150 @@
     {
         public int ChannelId { get; set; }
         public int ProgramId { get; set; }
-        public bool AutoSelect { get; set; }
+        public AutoSelect AutoSelect { get; set; }
         public int BatchSize { get; set; }
         public int MaxCoherentNok { get; set; }
+        //Rev 2 and Rev 999 for BatchCounter only
         public int BatchCounter { get; set; }
+        public int IdentifierNumber { get; set; }
+        public string JobStepName { get; set; }
+        public int JobStepType { get; set; }
+        //Rev 3
+        public ToolLoosening ToolLoosening { get; set; }
+        public BatchMode JobBatchMode { get; set; }
+        public BatchStatusAtIncrement BatchStatusAtIncrement { get; set; }
+        public DecrementBatchAfterLoosening DecrementBatchAfterLoosening { get; set; }
+        public CurrentBatchStatus CurrentBatchStatus { get; set; }
+
+        /// <summary>
+        /// Represents a advanced job entity
+        /// </summary>
+        public AdvancedJob()
+        {
+
+        }
+
+        /// <summary>
+        /// Revision 1 constructor
+        /// </summary>
+        /// <param name="channelId">two ASCII characters, range 00-99</param>
+        /// <param name="programId">parameter set ID or Multistage ID, three ASCII characters, range 000-999</param>
+        /// <param name="autoSelect">One ASCII character,
+        ///     <para>0=None</para>
+        ///     <para>1=Auto Next Change</para> 
+        ///     <para>2=I/O</para> 
+        ///     <para>6=Fieldbus</para> 
+        ///     <para>8=Socket tray</para>
+        /// </param>
+        /// <param name="batchSize">Two ASCII characters, range 00-99</param>
+        /// <param name="maxCoherentNok">Two ASCII characters, range 00-99</param>
+        public AdvancedJob(int channelId, int programId, AutoSelect autoSelect, int batchSize, int maxCoherentNok)
+        {
+            ChannelId = channelId;
+            ProgramId = programId;
+            AutoSelect = autoSelect;
+            BatchSize = batchSize;
+            MaxCoherentNok = maxCoherentNok;
+        }
+
+        /// <summary>
+        /// Revision 2 constructor
+        /// </summary>
+        /// <param name="channelId">two ASCII characters, range 00-99</param>
+        /// <param name="programId">parameter set ID or Multistage ID, three ASCII characters, range 000-999</param>
+        /// <param name="autoSelect">One ASCII character,
+        ///     <para>0=None</para>
+        ///     <para>1=Auto Next Change</para> 
+        ///     <para>2=I/O</para> 
+        ///     <para>6=Fieldbus</para> 
+        ///     <para>8=Socket tray</para>
+        /// </param>
+        /// <param name="batchSize">Two ASCII characters, range 00-99</param>
+        /// <param name="maxCoherentNok">Two ASCII characters, range 00-99</param>
+        /// <param name="batchCounter">Two ASCII characters, range 00-99</param>
+        /// <param name="identifierNumber">Four ASCII characters, range 0000-9999 (Socket(s), EndFitting(s)…)</param>
+        /// <param name="jobStepName">25 ASCII characters</param>
+        /// <param name="jobStepType">Two ASCII characters, range 00-99</param>
+        public AdvancedJob(int channelId, int programId, AutoSelect autoSelect, int batchSize, int maxCoherentNok, int batchCounter, 
+            int identifierNumber, string jobStepName, int jobStepType) : this(channelId, programId, autoSelect, batchSize, maxCoherentNok, batchCounter)
+        {
+            IdentifierNumber = identifierNumber;
+            JobStepName = jobStepName;
+            JobStepType = jobStepType;
+        }
+
+        /// <summary>
+        /// Revision 3 constructor
+        /// </summary>
+        /// <param name="channelId">two ASCII characters, range 00-99</param>
+        /// <param name="programId">parameter set ID or Multistage ID, three ASCII characters, range 000-999</param>
+        /// <param name="autoSelect">One ASCII character,
+        ///     <para>0=None</para>
+        ///     <para>1=Auto Next Change</para> 
+        ///     <para>2=I/O</para> 
+        ///     <para>6=Fieldbus</para> 
+        ///     <para>8=Socket tray</para>
+        /// </param>
+        /// <param name="batchSize">Two ASCII characters, range 00-99</param>
+        /// <param name="maxCoherentNok">Two ASCII characters, range 00-99</param>
+        /// <param name="batchCounter">Two ASCII characters, range 00-99</param>
+        /// <param name="identifierNumber">Four ASCII characters, range 0000-9999 (Socket(s), EndFitting(s)…)</param>
+        /// <param name="jobStepName">25 ASCII characters</param>
+        /// <param name="jobStepType">Two ASCII characters, range 00-99</param>
+        /// <param name="toolLoosening">1 ASCII character.
+        ///     <para>0=Enable</para> 
+        ///     <para>1=Disable</para>
+        ///     <para>2=Enable only on NOK tightening</para>
+        /// </param>
+        /// <param name="jobBatchMode">1 ASCII character. 
+        ///     <para>0=only the OK tightenings are counted</para>
+        ///     <para>1=both the OK and NOK tightenings are counted</para>
+        /// </param>
+        /// <param name="batchStatusAtIncrement">1 ASCII character. Batch status after performing an increment or a bypass parameter set: 
+        ///     <para>0=OK</para>
+        ///     <para>1=NOK</para>
+        /// </param>
+        /// <param name="decrementBatchAfterLoosening">1 ASCII character.
+        ///     <para>0=Never</para>
+        ///     <para>1=Always</para>
+        ///     <para>2=After OK</para>
+        /// </param>
+        /// <param name="currentBatchStatus">1 ASCII character: 
+        ///     <para>0=Not started</para>
+        ///     <para>1=OK</para>
+        ///     <para>2=NOK</para>
+        /// </param>
+        public AdvancedJob(int channelId, int programId, AutoSelect autoSelect, int batchSize, int maxCoherentNok, int batchCounter,
+            int identifierNumber, string jobStepName, int jobStepType, ToolLoosening toolLoosening, BatchMode jobBatchMode, 
+            BatchStatusAtIncrement batchStatusAtIncrement, DecrementBatchAfterLoosening decrementBatchAfterLoosening, CurrentBatchStatus currentBatchStatus) 
+            : this(channelId, programId, autoSelect, batchSize, maxCoherentNok, batchCounter, identifierNumber, jobStepName, jobStepType)
+        {
+            ToolLoosening = toolLoosening;
+            JobBatchMode = jobBatchMode;
+            BatchStatusAtIncrement = batchStatusAtIncrement;
+            DecrementBatchAfterLoosening = decrementBatchAfterLoosening;
+            CurrentBatchStatus = currentBatchStatus;
+        }
+
+        /// <summary>
+        /// Revision 999 constructor
+        /// </summary>
+        /// <param name="channelId">two ASCII characters, range 00-99</param>
+        /// <param name="programId">parameter set ID or Multistage ID, three ASCII characters, range 000-999</param>
+        /// <param name="autoSelect">One ASCII character,
+        ///     <para>0=None</para>
+        ///     <para>1=Auto Next Change</para> 
+        ///     <para>2=I/O</para> 
+        ///     <para>6=Fieldbus</para> 
+        ///     <para>8=Socket tray</para>
+        /// </param>
+        /// <param name="batchSize">Two ASCII characters, range 00-99</param>
+        /// <param name="maxCoherentNok">Two ASCII characters, range 00-99</param>
+        /// <param name="batchCounter">Two ASCII characters, range 00-99</param>
+        public AdvancedJob(int channelId, int programId, AutoSelect autoSelect, int batchSize, int maxCoherentNok, int batchCounter) 
+            : this(channelId, programId, autoSelect, batchSize, maxCoherentNok)
+        {
+            BatchCounter = batchCounter;
+        }
     }
 }

--- a/src/OpenProtocolInterpreter/Job/Advanced/Mid0140.cs
+++ b/src/OpenProtocolInterpreter/Job/Advanced/Mid0140.cs
@@ -22,99 +22,105 @@ namespace OpenProtocolInterpreter.Job.Advanced
         private readonly IValueConverter<int> _intConverter;
         private readonly IValueConverter<bool> _boolConverter;
         private IValueConverter<IEnumerable<AdvancedJob>> _jobListConverter;
-        private const int LAST_REVISION = 1;
+        private const int LAST_REVISION = 3;
         public const int MID = 140;
 
         public int JobId
         {
-            get => GetField(1, (int)DataFields.JOB_ID).GetValue(_intConverter.Convert);
-            set => GetField(1, (int)DataFields.JOB_ID).SetValue(_intConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.JOB_ID).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.JOB_ID).SetValue(_intConverter.Convert, value);
         }
         public string JobName
         {
-            get => GetField(1, (int)DataFields.JOB_NAME).Value;
-            set => GetField(1, (int)DataFields.JOB_NAME).SetValue(value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.JOB_NAME).Value;
+            set => GetField(GetNormalizedRevision(), (int)DataFields.JOB_NAME).SetValue(value);
         }
         public int NumberOfParameterSets
         {
-            get => GetField(1, (int)DataFields.NUMBER_OF_PARAMETER_SETS).GetValue(_intConverter.Convert);
-            set => GetField(1, (int)DataFields.NUMBER_OF_PARAMETER_SETS).SetValue(_intConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.NUMBER_OF_PARAMETER_SETS).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.NUMBER_OF_PARAMETER_SETS).SetValue(_intConverter.Convert, value);
         }
         public List<AdvancedJob> JobList { get; set; }
         public ForcedOrder ForcedOrder
         {
-            get => (ForcedOrder)GetField(1, (int)DataFields.FORCED_ORDER).GetValue(_intConverter.Convert);
-            set => GetField(1, (int)DataFields.FORCED_ORDER).SetValue(_intConverter.Convert, (int)value);
+            get => (ForcedOrder)GetField(GetNormalizedRevision(), (int)DataFields.FORCED_ORDER).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.FORCED_ORDER).SetValue(_intConverter.Convert, (int)value);
         }
         public bool LockAtJobDone
         {
-            get => GetField(1, (int)DataFields.LOCK_AT_JOB_DONE).GetValue(_boolConverter.Convert);
-            set => GetField(1, (int)DataFields.LOCK_AT_JOB_DONE).SetValue(_boolConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.LOCK_AT_JOB_DONE).GetValue(_boolConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.LOCK_AT_JOB_DONE).SetValue(_boolConverter.Convert, value);
         }
         public ToolLoosening ToolLoosening
         {
-            get => (ToolLoosening)GetField(1, (int)DataFields.TOOL_LOOSENING).GetValue(_intConverter.Convert);
-            set => GetField(1, (int)DataFields.TOOL_LOOSENING).SetValue(_intConverter.Convert, (int)value);
+            get => (ToolLoosening)GetField(GetNormalizedRevision(), (int)DataFields.TOOL_LOOSENING).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.TOOL_LOOSENING).SetValue(_intConverter.Convert, (int)value);
         }
         public bool RepeatJob
         {
-            get => GetField(1, (int)DataFields.REPEAT_JOB).GetValue(_boolConverter.Convert);
-            set => GetField(1, (int)DataFields.REPEAT_JOB).SetValue(_boolConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.REPEAT_JOB).GetValue(_boolConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.REPEAT_JOB).SetValue(_boolConverter.Convert, value);
         }
         public BatchMode BatchMode
         {
-            get => (BatchMode)GetField(1, (int)DataFields.JOB_BATCH_MODE).GetValue(_intConverter.Convert);
-            set => GetField(1, (int)DataFields.JOB_BATCH_MODE).SetValue(_intConverter.Convert, (int)value);
+            get => (BatchMode)GetField(GetNormalizedRevision(), (int)DataFields.JOB_BATCH_MODE).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.JOB_BATCH_MODE).SetValue(_intConverter.Convert, (int)value);
         }
         public bool BatchStatusAtIncrement
         {
-            get => GetField(1, (int)DataFields.BATCH_STATUS_AT_INCREMENT).GetValue(_boolConverter.Convert);
-            set => GetField(1, (int)DataFields.BATCH_STATUS_AT_INCREMENT).SetValue(_boolConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.BATCH_STATUS_AT_INCREMENT).GetValue(_boolConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.BATCH_STATUS_AT_INCREMENT).SetValue(_boolConverter.Convert, value);
         }
         public bool DecrementBatchAtOkLoosening
         {
-            get => GetField(1, (int)DataFields.DECREMENT_BATCH_AT_OK_LOOSENING).GetValue(_boolConverter.Convert);
-            set => GetField(1, (int)DataFields.DECREMENT_BATCH_AT_OK_LOOSENING).SetValue(_boolConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.DECREMENT_BATCH_AT_OK_LOOSENING).GetValue(_boolConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.DECREMENT_BATCH_AT_OK_LOOSENING).SetValue(_boolConverter.Convert, value);
         }
         public int MaxTimeForFirstTightening
         {
-            get => GetField(1, (int)DataFields.MAX_TIME_FOR_FIRST_TIGHTENING).GetValue(_intConverter.Convert);
-            set => GetField(1, (int)DataFields.MAX_TIME_FOR_FIRST_TIGHTENING).SetValue(_intConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.MAX_TIME_FOR_FIRST_TIGHTENING).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.MAX_TIME_FOR_FIRST_TIGHTENING).SetValue(_intConverter.Convert, value);
         }
         public int MaxTimeToCompleteJob
         {
-            get => GetField(1, (int)DataFields.MAX_TIME_TO_COMPLETE_JOB).GetValue(_intConverter.Convert);
-            set => GetField(1, (int)DataFields.MAX_TIME_TO_COMPLETE_JOB).SetValue(_intConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.MAX_TIME_TO_COMPLETE_JOB).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.MAX_TIME_TO_COMPLETE_JOB).SetValue(_intConverter.Convert, value);
         }
         public int DisplayResultAtAutoSelect
         {
-            get => GetField(1, (int)DataFields.DISPLAY_RESULT_AT_AUTO_SELECT).GetValue(_intConverter.Convert);
-            set => GetField(1, (int)DataFields.DISPLAY_RESULT_AT_AUTO_SELECT).SetValue(_intConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.DISPLAY_RESULT_AT_AUTO_SELECT).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.DISPLAY_RESULT_AT_AUTO_SELECT).SetValue(_intConverter.Convert, value);
         }
         public bool UsingLineControl
         {
-            get => GetField(1, (int)DataFields.USE_LINE_CONTROL).GetValue(_boolConverter.Convert);
-            set => GetField(1, (int)DataFields.USE_LINE_CONTROL).SetValue(_boolConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.USE_LINE_CONTROL).GetValue(_boolConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.USE_LINE_CONTROL).SetValue(_boolConverter.Convert, value);
         }
         public IdentifierPart IdentifierResultPart
         {
-            get => (IdentifierPart)GetField(1, (int)DataFields.IDENTIFIER_RESULT_PART).GetValue(_intConverter.Convert);
-            set => GetField(1, (int)DataFields.IDENTIFIER_RESULT_PART).SetValue(_intConverter.Convert, (int)value);
+            get => (IdentifierPart)GetField(GetNormalizedRevision(), (int)DataFields.IDENTIFIER_RESULT_PART).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.IDENTIFIER_RESULT_PART).SetValue(_intConverter.Convert, (int)value);
         }
         public bool ResultOfNonTightenings
         {
-            get => GetField(1, (int)DataFields.RESULT_OF_NON_TIGHTENINGS).GetValue(_boolConverter.Convert);
-            set => GetField(1, (int)DataFields.RESULT_OF_NON_TIGHTENINGS).SetValue(_boolConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.RESULT_OF_NON_TIGHTENINGS).GetValue(_boolConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.RESULT_OF_NON_TIGHTENINGS).SetValue(_boolConverter.Convert, value);
         }
         public bool ResetAllIdentifiersAtJobDone
         {
-            get => GetField(1, (int)DataFields.RESET_ALL_IDENTIFIERS_AT_JOB_DONE).GetValue(_boolConverter.Convert);
-            set => GetField(1, (int)DataFields.RESET_ALL_IDENTIFIERS_AT_JOB_DONE).SetValue(_boolConverter.Convert, value);
+            get => GetField(GetNormalizedRevision(), (int)DataFields.RESET_ALL_IDENTIFIERS_AT_JOB_DONE).GetValue(_boolConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.RESET_ALL_IDENTIFIERS_AT_JOB_DONE).SetValue(_boolConverter.Convert, value);
         }
         public Reserved Reserved
         {
-            get => (Reserved)GetField(1, (int)DataFields.RESERVED).GetValue(_intConverter.Convert);
-            set => GetField(1, (int)DataFields.RESERVED).SetValue(_intConverter.Convert, (int)value);
+            get => (Reserved)GetField(GetNormalizedRevision(), (int)DataFields.RESERVED).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.RESERVED).SetValue(_intConverter.Convert, (int)value);
+        }
+
+        public int JobSequenceNumber
+        {
+            get => GetField(GetNormalizedRevision(), (int)DataFields.JOB_SEQUENCE_NUMBER).GetValue(_intConverter.Convert);
+            set => GetField(GetNormalizedRevision(), (int)DataFields.JOB_SEQUENCE_NUMBER).SetValue(_intConverter.Convert, value);
         }
 
         public Mid0140() : this(LAST_REVISION)
@@ -127,41 +133,74 @@ namespace OpenProtocolInterpreter.Job.Advanced
             JobList = new List<AdvancedJob>();
             _intConverter = new Int32Converter();
             _boolConverter = new BoolConverter();
-            _jobListConverter = new AdvancedJobListConverter(_intConverter, _boolConverter, revision);
+            _jobListConverter = new AdvancedJobListConverter(_intConverter, revision);
         }
 
         public override string Pack()
         {
-            GetField(1, (int)DataFields.JOB_LIST).Size = JobList.Count * ((HeaderData.Revision == 999) ? 18 : 15);
+            var revision = GetNormalizedRevision();
+            var jobListField = GetField(revision, (int)DataFields.JOB_LIST);
+            jobListField.Size = JobList.Count * GetJobListSize();
             AdjustDataFieldsIndexes();
-            GetField(1, (int)DataFields.JOB_LIST).Value = _jobListConverter.Convert(JobList);
+            jobListField.Value = _jobListConverter.Convert(JobList);
             return base.Pack();
         }
 
         public override Mid Parse(string package)
         {
             HeaderData = ProcessHeader(package);
-            _jobListConverter = new AdvancedJobListConverter(_intConverter, _boolConverter, HeaderData.Revision);
+            _jobListConverter = new AdvancedJobListConverter(_intConverter, HeaderData.Revision);
             int length = HeaderData.Length;
-            foreach (var rev in RevisionsByFields[1])
+            var revision = GetNormalizedRevision();
+            foreach (var rev in RevisionsByFields[revision])
                 length -= rev.Size;
 
-            GetField(1, (int)DataFields.JOB_LIST).Size = length;
+            var jobListField = GetField(revision, (int)DataFields.JOB_LIST);
+            jobListField.Size = length;
             AdjustDataFieldsIndexes();
             base.ProcessDataFields(package);
-            JobList = _jobListConverter.Convert(GetField(1, (int)DataFields.JOB_LIST).Value).ToList();
+            JobList = _jobListConverter.Convert(jobListField.Value).ToList();
             return this;
         }
 
         private void AdjustDataFieldsIndexes()
         {
-            int index = GetField(1, (int)DataFields.JOB_LIST).Index + GetField(1, (int)DataFields.JOB_LIST).Size + 2;
-            for (int i = (int)DataFields.FORCED_ORDER; i < RevisionsByFields[1].Count; i++)
+            var revision = GetNormalizedRevision();
+            var jobListField = GetField(revision, (int)DataFields.JOB_LIST);
+            jobListField.Size = NumberOfParameterSets * GetJobListSize();
+            int index = jobListField.Index + jobListField.Size + 2;
+            int startAt = revision != 2 ? (int)DataFields.FORCED_ORDER : (int)DataFields.JOB_SEQUENCE_NUMBER;
+            foreach (var field in RevisionsByFields[revision])
             {
-                GetField(1, i).Index = index;
-                index += 2 + GetField(1, i).Size;
+                if (field.Field >= startAt)
+                {
+                    field.Index = index;
+                    index += 2 + field.Size;
+                }
             }
-            GetField(1, (int)DataFields.JOB_LIST).Size = NumberOfParameterSets * 15;
+
+        }
+
+        private int GetNormalizedRevision()
+        {
+            if (HeaderData.Revision == 999)
+            {
+                return 1;
+            }
+
+            return HeaderData.Revision;
+        }
+
+        private int GetJobListSize()
+        {
+            var revision = GetNormalizedRevision();
+            return revision switch
+            {
+                2 => 52,
+                3 => 63,
+                999 => 18,
+                _ => 15,
+            };
         }
 
         protected override Dictionary<int, List<DataField>> RegisterDatafields()
@@ -191,6 +230,36 @@ namespace OpenProtocolInterpreter.Job.Advanced
                                         new DataField((int)DataFields.RESET_ALL_IDENTIFIERS_AT_JOB_DONE, 0, 1),
                                         new DataField((int)DataFields.RESERVED, 0, 1)
                                 }
+                    },
+                    {
+                        2, new List<DataField>()
+                                {
+                                        new DataField((int)DataFields.JOB_ID, 20, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                        new DataField((int)DataFields.JOB_NAME, 26, 25, ' '),
+                                        new DataField((int)DataFields.NUMBER_OF_PARAMETER_SETS, 53, 2, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                        new DataField((int)DataFields.JOB_LIST, 57, 0),
+                                        new DataField((int)DataFields.JOB_SEQUENCE_NUMBER, 0, 5),
+                                }
+                    },
+                    {
+                        3, new List<DataField>()
+                                {
+                                        new DataField((int)DataFields.JOB_ID, 20, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                        new DataField((int)DataFields.JOB_NAME, 26, 25, ' '),
+                                        new DataField((int)DataFields.NUMBER_OF_PARAMETER_SETS, 53, 2, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                        new DataField((int)DataFields.JOB_LIST, 57, 0),
+                                        new DataField((int)DataFields.FORCED_ORDER, 0, 1),
+                                        new DataField((int)DataFields.LOCK_AT_JOB_DONE, 0, 1),
+                                        new DataField((int)DataFields.MAX_TIME_FOR_FIRST_TIGHTENING, 0, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                        new DataField((int)DataFields.MAX_TIME_TO_COMPLETE_JOB, 0, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                        new DataField((int)DataFields.DISPLAY_RESULT_AT_AUTO_SELECT, 0, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                        new DataField((int)DataFields.USE_LINE_CONTROL, 0, 1),
+                                        new DataField((int)DataFields.IDENTIFIER_RESULT_PART, 0, 1),
+                                        new DataField((int)DataFields.RESULT_OF_NON_TIGHTENINGS, 0, 1),
+                                        new DataField((int)DataFields.RESET_ALL_IDENTIFIERS_AT_JOB_DONE, 0, 1),
+                                        new DataField((int)DataFields.RESERVED, 0, 1),
+                                        new DataField((int)DataFields.JOB_SEQUENCE_NUMBER, 0, 5)
+                                }
                     }
                 };
         }
@@ -215,7 +284,10 @@ namespace OpenProtocolInterpreter.Job.Advanced
             IDENTIFIER_RESULT_PART,
             RESULT_OF_NON_TIGHTENINGS,
             RESET_ALL_IDENTIFIERS_AT_JOB_DONE,
-            RESERVED
+            RESERVED,
+
+            //Rev 2
+            JOB_SEQUENCE_NUMBER
         }
     }
 }

--- a/src/OpenProtocolInterpreter/Job/Mid0032.cs
+++ b/src/OpenProtocolInterpreter/Job/Mid0032.cs
@@ -14,7 +14,7 @@ namespace OpenProtocolInterpreter.Job
     public class Mid0032 : Mid, IJob, IIntegrator
     {
         private readonly IValueConverter<int> _intConverter;
-        private const int LAST_REVISION = 3;
+        private const int LAST_REVISION = 4;
         public const int MID = 32;
 
         public int JobId
@@ -35,14 +35,17 @@ namespace OpenProtocolInterpreter.Job
         }
 
         /// <summary>
-        /// Revision 1 or 2 setter
+        /// Revision 1, 2, 3 and 4 constructor
         /// </summary>
         /// <param name="jobId">
         ///     Revision 1 range: 00-99 
         ///     <para>Revision 2 range: 0000-9999</para>
         /// </param>
-        /// <param name="revision">Revision number (default = 3)</param>
-        public Mid0032(int jobId, int revision = 2) : this(revision) => JobId = jobId;
+        /// <param name="revision">Revision number (default = 4)</param>
+        public Mid0032(int jobId, int revision = LAST_REVISION) : this(revision)
+        {
+            JobId = jobId;
+        }
 
         public override Mid Parse(string package)
         {
@@ -62,9 +65,7 @@ namespace OpenProtocolInterpreter.Job
                             {
                                 new DataField((int)DataFields.JOB_ID, 20, 2, '0', DataField.PaddingOrientations.LEFT_PADDED, false),
                             }
-                },
-                { 2, new List<DataField>() },
-                { 3, new List<DataField>() }
+                }
             };
         }
 

--- a/src/OpenProtocolInterpreter/MID.cs
+++ b/src/OpenProtocolInterpreter/MID.cs
@@ -42,8 +42,13 @@ namespace OpenProtocolInterpreter
             {
                 HeaderData.Length = 20;
                 for (int i = 1; i <= (HeaderData.Revision > 0 ? HeaderData.Revision : 1); i++)
-                    foreach (var dataField in RevisionsByFields[i])
-                        HeaderData.Length += (dataField.HasPrefix ? 2 : 0) + dataField.Size;
+                {
+                    if (RevisionsByFields.TryGetValue(i, out var dataFields))
+                    {
+                        foreach (var dataField in dataFields)
+                            HeaderData.Length += (dataField.HasPrefix ? 2 : 0) + dataField.Size;
+                    }
+                }
             }
             return HeaderData.ToString();
         }
@@ -56,7 +61,12 @@ namespace OpenProtocolInterpreter
             string package = BuildHeader();
             int prefixIndex = 1;
             for (int i = 1; i <= (HeaderData.Revision > 0 ? HeaderData.Revision : 1); i++)
-                package += Pack(RevisionsByFields[i], ref prefixIndex);
+            {
+                if (RevisionsByFields.TryGetValue(i, out var dataFields))
+                {
+                    package += Pack(dataFields, ref prefixIndex);
+                }
+            }
 
             return package;
         }
@@ -84,7 +94,7 @@ namespace OpenProtocolInterpreter
 
         protected virtual Header ProcessHeader(string package)
         {
-            Header header = new Header
+            var header = new Header
             {
                 Length = Convert.ToInt32(package.Substring(0, 4)),
                 Mid = Convert.ToInt32(package.Substring(4, 4)),

--- a/src/OpenProtocolInterpreter/MID.cs
+++ b/src/OpenProtocolInterpreter/MID.cs
@@ -10,7 +10,7 @@ namespace OpenProtocolInterpreter
     /// </summary>
     public abstract class Mid
     {
-        public Dictionary<int, List<DataField>> RevisionsByFields { get; set; }
+        protected Dictionary<int, List<DataField>> RevisionsByFields { get; }
         public Header HeaderData { get; set; }
 
         public Mid(Header header)

--- a/src/OpenProtocolInterpreter/ParameterSet/Mid0012.cs
+++ b/src/OpenProtocolInterpreter/ParameterSet/Mid0012.cs
@@ -16,7 +16,7 @@ namespace OpenProtocolInterpreter.ParameterSet
     public class Mid0012 : Mid, IParameterSet, IIntegrator
     {
         private readonly IValueConverter<int> _intConverter;
-        private const int LAST_REVISION = 4;
+        private const int LAST_REVISION = 5;
         public const int MID = 12;
 
         public int ParameterSetId
@@ -41,7 +41,7 @@ namespace OpenProtocolInterpreter.ParameterSet
         }
 
         /// <summary>
-        /// Revision 1 and 2 Constructor
+        /// Revision 1, 2 and 5 Constructor
         /// </summary>
         /// <param name="parameterSetId">Parameter Set Id. Three ASCII digits. Range: 000-999</param>
         /// <param name="revision">Revision</param>

--- a/src/OpenProtocolInterpreter/ParameterSet/Mid0013.cs
+++ b/src/OpenProtocolInterpreter/ParameterSet/Mid0013.cs
@@ -15,69 +15,76 @@ namespace OpenProtocolInterpreter.ParameterSet
     {
         private readonly IValueConverter<int> _intConverter;
         private readonly IValueConverter<decimal> _decimalConverter;
-        private const int LAST_REVISION = 2;
+        private readonly IValueConverter<DateTime> _dateConverter;
+        private const int LAST_REVISION = 5;
         public const int MID = 13;
 
         public int ParameterSetId
         {
-            get => GetField(1,(int)DataFields.PARAMETER_SET_ID).GetValue(_intConverter.Convert);
-            set => GetField(1,(int)DataFields.PARAMETER_SET_ID).SetValue(_intConverter.Convert, value);
+            get => GetField(1, (int)DataFields.PARAMETER_SET_ID).GetValue(_intConverter.Convert);
+            set => GetField(1, (int)DataFields.PARAMETER_SET_ID).SetValue(_intConverter.Convert, value);
         }
         public string ParameterSetName
         {
-            get => GetField(1,(int)DataFields.PARAMETER_SET_NAME).Value;
-            set => GetField(1,(int)DataFields.PARAMETER_SET_NAME).SetValue(value);
+            get => GetField(1, (int)DataFields.PARAMETER_SET_NAME).Value;
+            set => GetField(1, (int)DataFields.PARAMETER_SET_NAME).SetValue(value);
         }
         public RotationDirection RotationDirection
         {
-            get => (RotationDirection)GetField(1,(int)DataFields.ROTATION_DIRECTION).GetValue(_intConverter.Convert);
-            set => GetField(1,(int)DataFields.ROTATION_DIRECTION).SetValue(_intConverter.Convert, (int)value);
+            get => (RotationDirection)GetField(1, (int)DataFields.ROTATION_DIRECTION).GetValue(_intConverter.Convert);
+            set => GetField(1, (int)DataFields.ROTATION_DIRECTION).SetValue(_intConverter.Convert, (int)value);
         }
         public int BatchSize
         {
-            get => GetField(1,(int)DataFields.BATCH_SIZE).GetValue(_intConverter.Convert);
-            set => GetField(1,(int)DataFields.BATCH_SIZE).SetValue(_intConverter.Convert, value);
+            get => GetField(1, (int)DataFields.BATCH_SIZE).GetValue(_intConverter.Convert);
+            set => GetField(1, (int)DataFields.BATCH_SIZE).SetValue(_intConverter.Convert, value);
         }
         public decimal MinTorque
         {
-            get => GetField(1,(int)DataFields.MIN_TORQUE).GetValue(_decimalConverter.Convert);
-            set => GetField(1,(int)DataFields.MIN_TORQUE).SetValue(_decimalConverter.Convert, value);
+            get => GetField(1, (int)DataFields.MIN_TORQUE).GetValue(_decimalConverter.Convert);
+            set => GetField(1, (int)DataFields.MIN_TORQUE).SetValue(_decimalConverter.Convert, value);
         }
         public decimal MaxTorque
         {
-            get => GetField(1,(int)DataFields.MAX_TORQUE).GetValue(_decimalConverter.Convert);
-            set => GetField(1,(int)DataFields.MAX_TORQUE).SetValue(_decimalConverter.Convert, value);
+            get => GetField(1, (int)DataFields.MAX_TORQUE).GetValue(_decimalConverter.Convert);
+            set => GetField(1, (int)DataFields.MAX_TORQUE).SetValue(_decimalConverter.Convert, value);
         }
         public decimal TorqueFinalTarget
         {
-            get => GetField(1,(int)DataFields.TORQUE_FINAL_TARGET).GetValue(_decimalConverter.Convert);
-            set => GetField(1,(int)DataFields.TORQUE_FINAL_TARGET).SetValue(_decimalConverter.Convert, value);
+            get => GetField(1, (int)DataFields.TORQUE_FINAL_TARGET).GetValue(_decimalConverter.Convert);
+            set => GetField(1, (int)DataFields.TORQUE_FINAL_TARGET).SetValue(_decimalConverter.Convert, value);
         }
         public int MinAngle
         {
-            get => GetField(1,(int)DataFields.MIN_ANGLE).GetValue(_intConverter.Convert);
-            set => GetField(1,(int)DataFields.MIN_ANGLE).SetValue(_intConverter.Convert, value);
+            get => GetField(1, (int)DataFields.MIN_ANGLE).GetValue(_intConverter.Convert);
+            set => GetField(1, (int)DataFields.MIN_ANGLE).SetValue(_intConverter.Convert, value);
         }
         public int MaxAngle
         {
-            get => GetField(1,(int)DataFields.MAX_ANGLE).GetValue(_intConverter.Convert);
-            set => GetField(1,(int)DataFields.MAX_ANGLE).SetValue(_intConverter.Convert, value);
+            get => GetField(1, (int)DataFields.MAX_ANGLE).GetValue(_intConverter.Convert);
+            set => GetField(1, (int)DataFields.MAX_ANGLE).SetValue(_intConverter.Convert, value);
         }
         public int AngleFinalTarget
         {
-            get => GetField(1,(int)DataFields.ANGLE_FINAL_TARGET).GetValue(_intConverter.Convert);
-            set => GetField(1,(int)DataFields.ANGLE_FINAL_TARGET).SetValue(_intConverter.Convert, value);
+            get => GetField(1, (int)DataFields.ANGLE_FINAL_TARGET).GetValue(_intConverter.Convert);
+            set => GetField(1, (int)DataFields.ANGLE_FINAL_TARGET).SetValue(_intConverter.Convert, value);
         }
         //Rev 2
         public decimal FirstTarget
         {
-            get => GetField(2,(int)DataFields.FIRST_TARGET).GetValue(_decimalConverter.Convert);
-            set => GetField(2,(int)DataFields.FIRST_TARGET).SetValue(_decimalConverter.Convert, value);
+            get => GetField(2, (int)DataFields.FIRST_TARGET).GetValue(_decimalConverter.Convert);
+            set => GetField(2, (int)DataFields.FIRST_TARGET).SetValue(_decimalConverter.Convert, value);
         }
         public decimal StartFinalAngle
         {
-            get => GetField(2,(int)DataFields.START_FINAL_TARGET).GetValue(_decimalConverter.Convert);
-            set => GetField(2,(int)DataFields.START_FINAL_TARGET).SetValue(_decimalConverter.Convert, value);
+            get => GetField(2, (int)DataFields.START_FINAL_TARGET).GetValue(_decimalConverter.Convert);
+            set => GetField(2, (int)DataFields.START_FINAL_TARGET).SetValue(_decimalConverter.Convert, value);
+        }
+        //Rev 5
+        public DateTime LastChangeInParameterSet
+        {
+            get => GetField(5, (int)DataFields.LAST_CHANGE_IN_PARAMETER_SET).GetValue(_dateConverter.Convert);
+            set => GetField(5, (int)DataFields.LAST_CHANGE_IN_PARAMETER_SET).SetValue(_dateConverter.Convert, value);
         }
 
         public Mid0013() : this(LAST_REVISION)
@@ -89,6 +96,7 @@ namespace OpenProtocolInterpreter.ParameterSet
         {
             _intConverter = new Int32Converter();
             _decimalConverter = new DecimalTrucatedConverter(2);
+            _dateConverter = new DateConverter();
         }
 
         /// <summary>
@@ -105,7 +113,7 @@ namespace OpenProtocolInterpreter.ParameterSet
         /// <param name="maxAngle">The angle max value is five bytes long and is specified by five ASCII digits.Range: 00000-99999.</param>
         /// <param name="angleFinalTarget">The target angle is specified in degrees. 5 ASCII digits. Range: 00000-99999.</param>
         /// <param name="revision">Revision number (default = 1)</param>
-        public Mid0013(int parameterSetId, string parameterSetName, RotationDirection rotationDirection, int batchSize, decimal minTorque, decimal maxTorque, 
+        public Mid0013(int parameterSetId, string parameterSetName, RotationDirection rotationDirection, int batchSize, decimal minTorque, decimal maxTorque,
             decimal torqueFinalTarget, int minAngle, int maxAngle, int angleFinalTarget, int revision = 1) : this(revision)
         {
             ParameterSetId = parameterSetId;
@@ -136,13 +144,38 @@ namespace OpenProtocolInterpreter.ParameterSet
         /// <param name="firstTarget">The torque first target is multiplied by 100 and sent as an integer (2 decimals truncated). It is six bytes long and is specified by six ASCII digits.</param>
         /// <param name="startFinalAngle">The start final angle is the torque to reach the snug level. The start final angle is multiplied by 100 and sent as an integer (2 decimals truncated). It is six bytes long and is specified by six ASCII digits.</param>
         /// <param name="revision">Revision number (default = 1)</param>
-        public Mid0013(int parameterSetId, string parameterSetName, RotationDirection rotationDirection, int batchSize, decimal minTorque, decimal maxTorque, 
-            decimal torqueFinalTarget, int minAngle, int maxAngle, int angleFinalTarget, decimal firstTarget, decimal startFinalAngle, int revision = 2) 
-            : this(parameterSetId, parameterSetName, rotationDirection, batchSize, minTorque, maxTorque, 
+        public Mid0013(int parameterSetId, string parameterSetName, RotationDirection rotationDirection, int batchSize, decimal minTorque, decimal maxTorque,
+            decimal torqueFinalTarget, int minAngle, int maxAngle, int angleFinalTarget, decimal firstTarget, decimal startFinalAngle, int revision = 2)
+            : this(parameterSetId, parameterSetName, rotationDirection, batchSize, minTorque, maxTorque,
                   torqueFinalTarget, minAngle, maxAngle, angleFinalTarget, revision)
         {
             FirstTarget = firstTarget;
             StartFinalAngle = startFinalAngle;
+        }
+
+        /// <summary>
+        /// Revision 5 Constructor
+        /// </summary>
+        /// <param name="parameterSetId">Three ASCII digits, range 000-999</param>
+        /// <param name="parameterSetName">25 ASCII characters. Right padded with space if name is less than 25 characters.</param>
+        /// <param name="rotationDirection">1=CW (Clockwise), 2=CCW (Counter Clockwise)</param>
+        /// <param name="batchSize">2 ASCII digits, range 00-99</param>
+        /// <param name="minTorque">The torque min limit is multiplied by 100 and sent as an integer (2 decimals truncated). It is six bytes long and is specified by six ASCII digits.</param>
+        /// <param name="maxTorque">The torque max limit is multiplied by 100 and sent as an integer (2 decimals truncated). It is six bytes long and is specified by six ASCII digits.</param>
+        /// <param name="torqueFinalTarget">The torque final target is multiplied by 100 and sent as an integer (2 decimals truncated). It is six bytes long and is specified by six ASCII digits.</param>
+        /// <param name="minAngle">The angle min value is five bytes long and is specified by five ASCII digits.Range: 00000-99999.</param>
+        /// <param name="maxAngle">The angle max value is five bytes long and is specified by five ASCII digits.Range: 00000-99999.</param>
+        /// <param name="angleFinalTarget">The target angle is specified in degrees. 5 ASCII digits. Range: 00000-99999.</param>
+        /// <param name="firstTarget">The torque first target is multiplied by 100 and sent as an integer (2 decimals truncated). It is six bytes long and is specified by six ASCII digits.</param>
+        /// <param name="startFinalAngle">The start final angle is the torque to reach the snug level. The start final angle is multiplied by 100 and sent as an integer (2 decimals truncated). It is six bytes long and is specified by six ASCII digits.</param>
+        /// <param name="lastChangeInParameterSet">Date of last change in parameter set setting</param>
+        /// <param name="revision">Revision number (default = 1)</param>
+        public Mid0013(int parameterSetId, string parameterSetName, RotationDirection rotationDirection, int batchSize, decimal minTorque, decimal maxTorque,
+            decimal torqueFinalTarget, int minAngle, int maxAngle, int angleFinalTarget, decimal firstTarget, decimal startFinalAngle, DateTime lastChangeInParameterSet, int revision = 5)
+            : this(parameterSetId, parameterSetName, rotationDirection, batchSize, minTorque, maxTorque,
+                  torqueFinalTarget, minAngle, maxAngle, angleFinalTarget, firstTarget, startFinalAngle, revision)
+        {
+            LastChangeInParameterSet = lastChangeInParameterSet;
         }
 
         /// <summary>
@@ -194,6 +227,18 @@ namespace OpenProtocolInterpreter.ParameterSet
                                 new DataField((int)DataFields.FIRST_TARGET, 104, 6, '0', DataField.PaddingOrientations.LEFT_PADDED),
                                 new DataField((int)DataFields.START_FINAL_TARGET, 112, 6, '0', DataField.PaddingOrientations.LEFT_PADDED)
                             }
+                },
+                {
+                    3, new  List<DataField>()
+                },
+                {
+                    4, new  List<DataField>()
+                },
+                {
+                    5, new  List<DataField>()
+                            {
+                                new DataField((int)DataFields.LAST_CHANGE_IN_PARAMETER_SET, 120, 19),
+                            }
                 }
             };
         }
@@ -212,7 +257,9 @@ namespace OpenProtocolInterpreter.ParameterSet
             ANGLE_FINAL_TARGET,
             //Rev 2
             FIRST_TARGET,
-            START_FINAL_TARGET
+            START_FINAL_TARGET,
+            //Rev 5
+            LAST_CHANGE_IN_PARAMETER_SET
         }
     }
 }

--- a/src/OpenProtocolInterpreter/Result/Mid1201.cs
+++ b/src/OpenProtocolInterpreter/Result/Mid1201.cs
@@ -27,10 +27,15 @@ namespace OpenProtocolInterpreter.Result
         private readonly IValueConverter<IEnumerable<ObjectData>> _objectDataListConverter;
         private readonly IValueConverter<IEnumerable<VariableDataField>> _varDataFieldListConverter;
 
-        private const int LAST_REVISION = 1;
+        private const int LAST_REVISION = 2;
         public const int MID = 1201;
 
-        public Mid1201() : base(MID, LAST_REVISION)
+        public Mid1201() : this(LAST_REVISION)
+        {
+
+        }
+
+        public Mid1201(int revision = LAST_REVISION) : base(MID, revision)
         {
             _intConverter = new Int32Converter();
             _dateConverter = new DateConverter();

--- a/src/OpenProtocolInterpreter/Tool/Mid0040.cs
+++ b/src/OpenProtocolInterpreter/Tool/Mid0040.cs
@@ -1,4 +1,7 @@
-﻿namespace OpenProtocolInterpreter.Tool
+﻿using OpenProtocolInterpreter.Converters;
+using System.Collections.Generic;
+
+namespace OpenProtocolInterpreter.Tool
 {
     /// <summary>
     /// Tool data upload request
@@ -11,9 +14,52 @@
     /// </summary>
     public class Mid0040 : Mid, ITool, IIntegrator
     {
-        private const int LAST_REVISION = 5;
+        private readonly IValueConverter<int> _intConverter;
+        private const int LAST_REVISION = 7;
         public const int MID = 40;
 
-        public Mid0040() : base(MID, LAST_REVISION) { }
+        public int ToolNumber
+        {
+            get => GetField(6, (int)DataFields.TOOL_NUMBER).GetValue(_intConverter.Convert);
+            set => GetField(6, (int)DataFields.TOOL_NUMBER).SetValue(_intConverter.Convert, value);
+        }
+
+        public Mid0040() : this(LAST_REVISION)
+        {
+
+        }
+
+        public Mid0040(int revision = 7) : base(MID, revision)
+        {
+            _intConverter = new Int32Converter();
+        }
+
+        /// <summary>
+        /// Revision 6 and 7 constructor
+        /// </summary>
+        /// <param name="toolNumber">The number of the tool to send tool data for. It is the same number as the tool numbers sent in <see cref="Mid0701"/> (Tool List Upload)</param>
+        /// <param name="revision">Revision</param>
+        public Mid0040(int toolNumber, int revision = 7) : this(revision)
+        {
+            ToolNumber = toolNumber;
+        }
+
+        protected override Dictionary<int, List<DataField>> RegisterDatafields()
+        {
+            return new Dictionary<int, List<DataField>>()
+            {
+                {
+                    6, new List<DataField>()
+                            {
+                                new DataField((int)DataFields.TOOL_NUMBER, 20, 4, '0', DataField.PaddingOrientations.LEFT_PADDED)
+                            }
+                },
+            };
+        }
+
+        public enum DataFields
+        {
+            TOOL_NUMBER
+        }
     }
 }

--- a/src/OpenProtocolInterpreter/Tool/Mid0041.cs
+++ b/src/OpenProtocolInterpreter/Tool/Mid0041.cs
@@ -18,92 +18,119 @@ namespace OpenProtocolInterpreter.Tool
         private readonly IValueConverter<DateTime> _dateConverter;
         private readonly IValueConverter<decimal> _decimalConverter;
         private readonly IValueConverter<OpenEndDatas> _openEndDataConverter;
-        private const int LAST_REVISION = 5;
+        private const int LAST_REVISION = 7;
         public const int MID = 41;
 
         public string ToolSerialNumber
         {
-            get => GetField(1,(int)DataFields.TOOL_SERIAL_NUMBER).Value;
-            set => GetField(1,(int)DataFields.TOOL_SERIAL_NUMBER).SetValue(value);
+            get => GetField(1, (int)DataFields.TOOL_SERIAL_NUMBER).Value;
+            set => GetField(1, (int)DataFields.TOOL_SERIAL_NUMBER).SetValue(value);
         }
         public long ToolNumberOfTightenings
-        { 
-            get => GetField(1,(int)DataFields.TOOL_NUMBER_OF_TIGHTENINGS).GetValue(_longConverter.Convert);
-            set => GetField(1,(int)DataFields.TOOL_NUMBER_OF_TIGHTENINGS).SetValue(_longConverter.Convert, value);
+        {
+            get => GetField(1, (int)DataFields.TOOL_NUMBER_OF_TIGHTENINGS).GetValue(_longConverter.Convert);
+            set => GetField(1, (int)DataFields.TOOL_NUMBER_OF_TIGHTENINGS).SetValue(_longConverter.Convert, value);
         }
         public DateTime LastCalibrationDate
         {
-            get => GetField(1,(int)DataFields.LAST_CALIBRATION_DATE).GetValue(_dateConverter.Convert);
-            set => GetField(1,(int)DataFields.LAST_CALIBRATION_DATE).SetValue(_dateConverter.Convert, value);
+            get => GetField(1, (int)DataFields.LAST_CALIBRATION_DATE).GetValue(_dateConverter.Convert);
+            set => GetField(1, (int)DataFields.LAST_CALIBRATION_DATE).SetValue(_dateConverter.Convert, value);
         }
         public string ControllerSerialNumber
         {
-            get => GetField(1,(int)DataFields.CONTROLLER_SERIAL_NUMBER).Value;
-            set => GetField(1,(int)DataFields.CONTROLLER_SERIAL_NUMBER).SetValue(value);
+            get => GetField(1, (int)DataFields.CONTROLLER_SERIAL_NUMBER).Value;
+            set => GetField(1, (int)DataFields.CONTROLLER_SERIAL_NUMBER).SetValue(value);
         }
         //Rev 2
         public decimal CalibrationValue
         {
-            get => GetField(2,(int)DataFields.CALIBRATION_VALUE).GetValue(_decimalConverter.Convert);
-            set => GetField(2,(int)DataFields.CALIBRATION_VALUE).SetValue(_decimalConverter.Convert, value);
+            get => GetField(2, (int)DataFields.CALIBRATION_VALUE).GetValue(_decimalConverter.Convert);
+            set => GetField(2, (int)DataFields.CALIBRATION_VALUE).SetValue(_decimalConverter.Convert, value);
         }
         public DateTime LastServiceDate
         {
-            get => GetField(2,(int)DataFields.LAST_SERVICE_DATE).GetValue(_dateConverter.Convert);
-            set => GetField(2,(int)DataFields.LAST_SERVICE_DATE).SetValue(_dateConverter.Convert, value);
+            get => GetField(2, (int)DataFields.LAST_SERVICE_DATE).GetValue(_dateConverter.Convert);
+            set => GetField(2, (int)DataFields.LAST_SERVICE_DATE).SetValue(_dateConverter.Convert, value);
         }
         public long TighteningsSinceService
         {
-            get => GetField(2,(int)DataFields.TIGHTENINGS_SINCE_SERVICE).GetValue(_longConverter.Convert);
-            set => GetField(2,(int)DataFields.TIGHTENINGS_SINCE_SERVICE).SetValue(_longConverter.Convert, value);
+            get => GetField(2, (int)DataFields.TIGHTENINGS_SINCE_SERVICE).GetValue(_longConverter.Convert);
+            set => GetField(2, (int)DataFields.TIGHTENINGS_SINCE_SERVICE).SetValue(_longConverter.Convert, value);
         }
         public ToolType ToolType
         {
-            get => (ToolType)GetField(2,(int)DataFields.TOOL_TYPE).GetValue(_intConverter.Convert);
-            set => GetField(2,(int)DataFields.TOOL_TYPE).SetValue(_intConverter.Convert, (int)value);
+            get => (ToolType)GetField(2, (int)DataFields.TOOL_TYPE).GetValue(_intConverter.Convert);
+            set => GetField(2, (int)DataFields.TOOL_TYPE).SetValue(_intConverter.Convert, (int)value);
         }
         public int MotorSize
         {
-            get => GetField(2,(int)DataFields.MOTOR_SIZE).GetValue(_intConverter.Convert);
-            set => GetField(2,(int)DataFields.MOTOR_SIZE).SetValue(_intConverter.Convert, value);
+            get => GetField(2, (int)DataFields.MOTOR_SIZE).GetValue(_intConverter.Convert);
+            set => GetField(2, (int)DataFields.MOTOR_SIZE).SetValue(_intConverter.Convert, value);
         }
         public OpenEndDatas OpenEndData
         {
-            get => GetField(2,(int)DataFields.OPEN_END_DATA).GetValue(_openEndDataConverter.Convert);
-            set => GetField(2,(int)DataFields.OPEN_END_DATA).SetValue(_openEndDataConverter.Convert, value);
+            get => GetField(2, (int)DataFields.OPEN_END_DATA).GetValue(_openEndDataConverter.Convert);
+            set => GetField(2, (int)DataFields.OPEN_END_DATA).SetValue(_openEndDataConverter.Convert, value);
         }
         public string ControllerSoftwareVersion
         {
-            get => GetField(2,(int)DataFields.CONTROLLER_SOFTWARE_VERSION).Value;
-            set => GetField(2,(int)DataFields.CONTROLLER_SOFTWARE_VERSION).SetValue(value);
+            get => GetField(2, (int)DataFields.CONTROLLER_SOFTWARE_VERSION).Value;
+            set => GetField(2, (int)DataFields.CONTROLLER_SOFTWARE_VERSION).SetValue(value);
         }
         //Rev 3
         public decimal ToolMaxTorque
         {
-            get => GetField(3,(int)DataFields.TOOL_MAX_TORQUE).GetValue(_decimalConverter.Convert);
-            set => GetField(3,(int)DataFields.TOOL_MAX_TORQUE).SetValue(_decimalConverter.Convert, value);
+            get => GetField(3, (int)DataFields.TOOL_MAX_TORQUE).GetValue(_decimalConverter.Convert);
+            set => GetField(3, (int)DataFields.TOOL_MAX_TORQUE).SetValue(_decimalConverter.Convert, value);
         }
         public decimal GearRatio
         {
-            get => GetField(3,(int)DataFields.GEAR_RATIO).GetValue(_decimalConverter.Convert);
-            set => GetField(3,(int)DataFields.GEAR_RATIO).SetValue(_decimalConverter.Convert, value);
+            get => GetField(3, (int)DataFields.GEAR_RATIO).GetValue(_decimalConverter.Convert);
+            set => GetField(3, (int)DataFields.GEAR_RATIO).SetValue(_decimalConverter.Convert, value);
         }
         public decimal ToolFullSpeed
         {
-            get => GetField(3,(int)DataFields.TOOL_FULL_SPEED).GetValue(_decimalConverter.Convert);
-            set => GetField(3,(int)DataFields.TOOL_FULL_SPEED).SetValue(_decimalConverter.Convert, value);
+            get => GetField(3, (int)DataFields.TOOL_FULL_SPEED).GetValue(_decimalConverter.Convert);
+            set => GetField(3, (int)DataFields.TOOL_FULL_SPEED).SetValue(_decimalConverter.Convert, value);
         }
         //Rev 4
         public PrimaryTool PrimaryTool
         {
-            get => (PrimaryTool)GetField(4,(int)DataFields.PRIMARY_TOOL).GetValue(_intConverter.Convert);
-            set => GetField(4,(int)DataFields.PRIMARY_TOOL).SetValue(_intConverter.Convert, (int)value);
+            get => (PrimaryTool)GetField(4, (int)DataFields.PRIMARY_TOOL).GetValue(_intConverter.Convert);
+            set => GetField(4, (int)DataFields.PRIMARY_TOOL).SetValue(_intConverter.Convert, (int)value);
         }
         //Rev 5
         public string ToolModel
         {
-            get => GetField(5,(int)DataFields.TOOL_MODEL).Value;
-            set => GetField(5,(int)DataFields.TOOL_MODEL).SetValue(value);
+            get => GetField(5, (int)DataFields.TOOL_MODEL).Value;
+            set => GetField(5, (int)DataFields.TOOL_MODEL).SetValue(value);
+        }
+        //Rev 6
+        public int ToolNumber
+        {
+            get => GetField(6, (int)DataFields.TOOL_NUMBER).GetValue(_intConverter.Convert);
+            set => GetField(6, (int)DataFields.TOOL_NUMBER).SetValue(_intConverter.Convert, value);
+        }
+        public string ToolArticleNumber
+        {
+            get => GetField(6, (int)DataFields.TOOL_ARTICLE_NUMBER).Value;
+            set => GetField(6, (int)DataFields.TOOL_ARTICLE_NUMBER).SetValue(value);
+        }
+        //Rev 7
+        public decimal RundownMinSpeed
+        {
+            get => GetField(7, (int)DataFields.RUNDOWN_MIN_SPEED).GetValue(_decimalConverter.Convert);
+            set => GetField(7, (int)DataFields.RUNDOWN_MIN_SPEED).SetValue(_decimalConverter.Convert, value);
+        }
+        public decimal DownshiftMaxSpeed
+        {
+            get => GetField(7, (int)DataFields.DOWNSHIFT_MAX_SPEED).GetValue(_decimalConverter.Convert);
+            set => GetField(7, (int)DataFields.DOWNSHIFT_MAX_SPEED).SetValue(_decimalConverter.Convert, value);
+        }
+        public decimal DownshiftMinSpeed
+        {
+            get => GetField(7, (int)DataFields.DOWNSHIFT_MIN_SPEED).GetValue(_decimalConverter.Convert);
+            set => GetField(7, (int)DataFields.DOWNSHIFT_MIN_SPEED).SetValue(_decimalConverter.Convert, value);
         }
 
         public Mid0041() : this(LAST_REVISION)
@@ -128,7 +155,7 @@ namespace OpenProtocolInterpreter.Tool
         /// <param name="lastCalibrationDate">19 ASCII characters.</param>
         /// <param name="controllerSerialNumber">10 ASCII characters</param>
         /// <param name="revision">Revision number (default = 1)</param>
-        public Mid0041(string toolSerialNumber, long toolNumberOfTightenings,  DateTime lastCalibrationDate, 
+        public Mid0041(string toolSerialNumber, long toolNumberOfTightenings, DateTime lastCalibrationDate,
             string controllerSerialNumber, int revision = 1) : this(revision)
         {
             ToolSerialNumber = toolSerialNumber;
@@ -160,10 +187,10 @@ namespace OpenProtocolInterpreter.Tool
         /// <para>The third digit indicates motor rotation: 0=normal,1=inverted.</para></param>
         /// <param name="controllerSoftwareVersion">The software version is specified by 19 ASCII characters.</param>
         /// <param name="revision">Revision number (default = 2)</param>
-        public Mid0041(string toolSerialNumber, long toolNumberOfTightenings, DateTime lastCalibrationDate, 
+        public Mid0041(string toolSerialNumber, long toolNumberOfTightenings, DateTime lastCalibrationDate,
             string controllerSerialNumber, decimal calibrationValue, DateTime lastServiceDate,
             long tighteningsSinceService, ToolType toolType, int motorSize, OpenEndDatas openEndData,
-            string controllerSoftwareVersion, int revision = 2) 
+            string controllerSoftwareVersion, int revision = 2)
             : this(toolSerialNumber, toolNumberOfTightenings, lastCalibrationDate, controllerSerialNumber, revision)
         {
             CalibrationValue = calibrationValue;
@@ -205,10 +232,10 @@ namespace OpenProtocolInterpreter.Tool
         public Mid0041(string toolSerialNumber, long toolNumberOfTightenings, DateTime lastCalibrationDate,
             string controllerSerialNumber, decimal calibrationValue, DateTime lastServiceDate,
             long tighteningsSinceService, ToolType toolType, int motorSize, OpenEndDatas openEndData,
-            string controllerSoftwareVersion, decimal toolMaxTorque, decimal gearRatio, decimal toolFullSpeed, 
-            int revision = 3) : this(toolSerialNumber, toolNumberOfTightenings, lastCalibrationDate, 
-                                        controllerSerialNumber, calibrationValue, lastServiceDate, 
-                                        tighteningsSinceService, toolType, motorSize, openEndData, 
+            string controllerSoftwareVersion, decimal toolMaxTorque, decimal gearRatio, decimal toolFullSpeed,
+            int revision = 3) : this(toolSerialNumber, toolNumberOfTightenings, lastCalibrationDate,
+                                        controllerSerialNumber, calibrationValue, lastServiceDate,
+                                        tighteningsSinceService, toolType, motorSize, openEndData,
                                         controllerSoftwareVersion, revision)
         {
             ToolMaxTorque = toolMaxTorque;
@@ -248,8 +275,8 @@ namespace OpenProtocolInterpreter.Tool
             string controllerSerialNumber, decimal calibrationValue, DateTime lastServiceDate,
             long tighteningsSinceService, ToolType toolType, int motorSize, OpenEndDatas openEndData,
             string controllerSoftwareVersion, decimal toolMaxTorque, decimal gearRatio, decimal toolFullSpeed,
-            PrimaryTool primaryTool, int revision = 4) 
-            : this(toolSerialNumber, toolNumberOfTightenings, lastCalibrationDate, controllerSerialNumber, 
+            PrimaryTool primaryTool, int revision = 4)
+            : this(toolSerialNumber, toolNumberOfTightenings, lastCalibrationDate, controllerSerialNumber,
                   calibrationValue, lastServiceDate, tighteningsSinceService, toolType, motorSize, openEndData,
                   controllerSoftwareVersion, toolMaxTorque, gearRatio, toolFullSpeed, revision)
         {
@@ -289,12 +316,112 @@ namespace OpenProtocolInterpreter.Tool
             string controllerSerialNumber, decimal calibrationValue, DateTime lastServiceDate,
             long tighteningsSinceService, ToolType toolType, int motorSize, OpenEndDatas openEndData,
             string controllerSoftwareVersion, decimal toolMaxTorque, decimal gearRatio, decimal toolFullSpeed,
-            PrimaryTool primaryTool, string toolModel , int revision = 5) 
-            : this(toolSerialNumber, toolNumberOfTightenings, lastCalibrationDate, controllerSerialNumber, 
+            PrimaryTool primaryTool, string toolModel, int revision = 5)
+            : this(toolSerialNumber, toolNumberOfTightenings, lastCalibrationDate, controllerSerialNumber,
                   calibrationValue, lastServiceDate, tighteningsSinceService, toolType, motorSize, openEndData,
                   controllerSoftwareVersion, toolMaxTorque, gearRatio, toolFullSpeed, primaryTool, revision)
         {
             ToolModel = toolModel;
+        }
+
+        /// <summary>
+        /// Revision 6 Constructor
+        /// </summary>
+        /// <param name="toolSerialNumber">14 ASCII characters</param>
+        /// <param name="toolNumberOfTightenings">10 ASCII digits. Max 4294967295</param>
+        /// <param name="lastCalibrationDate">19 ASCII characters.</param>
+        /// <param name="controllerSerialNumber">10 ASCII characters</param>
+        /// <param name="calibrationValue">The tool calibration value is multiplied by 100 and sent as an integer (2 decimals truncated). Six ASCII digits.</param>
+        /// <param name="lastServiceDate">19 ASCII characters.</param>
+        /// <param name="tighteningsSinceService">The number of tightenings since last service is specified by 10 ASCII digits. Max 4294967295.</param>
+        /// <param name="toolType">The tool type is specified by 2 ASCII digits</param>
+        /// <param name="motorSize">The motor size is specified by 2 ASCII digits, range 00-99.
+        /// <para>00 = no motor, 01-99 = motor size xx in Atlas Copco
+        /// nomenclature, or motor size = 10xx in Atlas Copco nomenclature </para>
+        /// <para>(certain numbers correspond to 2
+        /// different motor sizes, for example 62 for both motor
+        /// size 62 and motor size 1062)</para></param>
+        /// <param name="openEndData">The open end data is specified by 3 ASCII digits. 
+        /// <para>The first digit represents the “use open end”: 1=true, 0=false.</para>
+        /// <para>The second digit indicates the tightening direction: 0=CW, 1=CCW.</para>
+        /// <para>The third digit indicates motor rotation: 0=normal,1=inverted.</para>
+        /// </param>
+        /// <param name="controllerSoftwareVersion">The software version is specified by 19 ASCII characters.</param>
+        /// <param name="toolMaxTorque">The tool max toque value is multiplied by 100 and sent as an integer(2 decimals truncated). Six ASCII digits.</param>
+        /// <param name="gearRatio">The gear ratio value is multiplied by 100 and sent as an integer(2 decimals truncated). Six ASCII digits.</param>
+        /// <param name="toolFullSpeed">The tool full speed value is multiplied by 100 and sent as an integer(2 decimals truncated). Six ASCII digits.</param>
+        /// <param name="primaryTool">Primary tool. The primary tool is two byte-long and specified by two ASCII digits.</param>
+        /// <param name="toolModel">12 ASCII characters with padding at the end of the string if needed.The padding is done spaces.</param>
+        /// <param name="toolNumber">
+        ///     The number of the tool. It is the same number as the tool numbers sent in <see cref="Mid0701"/> (Tool List Upload) 
+        ///     <para>In systems with only 1 tool the number sent will always be <c>0001</c></para>
+        /// </param>
+        /// <param name="toolArticleNumber">Tool article number</param>
+        /// <param name="revision">Revision number (default = 6)</param>
+        public Mid0041(string toolSerialNumber, long toolNumberOfTightenings, DateTime lastCalibrationDate,
+            string controllerSerialNumber, decimal calibrationValue, DateTime lastServiceDate,
+            long tighteningsSinceService, ToolType toolType, int motorSize, OpenEndDatas openEndData,
+            string controllerSoftwareVersion, decimal toolMaxTorque, decimal gearRatio, decimal toolFullSpeed,
+            PrimaryTool primaryTool, string toolModel, int toolNumber, string toolArticleNumber, int revision = 6)
+            : this(toolSerialNumber, toolNumberOfTightenings, lastCalibrationDate, controllerSerialNumber,
+                  calibrationValue, lastServiceDate, tighteningsSinceService, toolType, motorSize, openEndData,
+                  controllerSoftwareVersion, toolMaxTorque, gearRatio, toolFullSpeed, primaryTool, toolModel, revision)
+        {
+            ToolNumber = toolNumber;
+            ToolArticleNumber = toolArticleNumber;
+        }
+
+        /// <summary>
+        /// Revision 7 Constructor
+        /// </summary>
+        /// <param name="toolSerialNumber">14 ASCII characters</param>
+        /// <param name="toolNumberOfTightenings">10 ASCII digits. Max 4294967295</param>
+        /// <param name="lastCalibrationDate">19 ASCII characters.</param>
+        /// <param name="controllerSerialNumber">10 ASCII characters</param>
+        /// <param name="calibrationValue">The tool calibration value is multiplied by 100 and sent as an integer (2 decimals truncated). Six ASCII digits.</param>
+        /// <param name="lastServiceDate">19 ASCII characters.</param>
+        /// <param name="tighteningsSinceService">The number of tightenings since last service is specified by 10 ASCII digits. Max 4294967295.</param>
+        /// <param name="toolType">The tool type is specified by 2 ASCII digits</param>
+        /// <param name="motorSize">The motor size is specified by 2 ASCII digits, range 00-99.
+        /// <para>00 = no motor, 01-99 = motor size xx in Atlas Copco
+        /// nomenclature, or motor size = 10xx in Atlas Copco nomenclature </para>
+        /// <para>(certain numbers correspond to 2
+        /// different motor sizes, for example 62 for both motor
+        /// size 62 and motor size 1062)</para></param>
+        /// <param name="openEndData">The open end data is specified by 3 ASCII digits. 
+        /// <para>The first digit represents the “use open end”: 1=true, 0=false.</para>
+        /// <para>The second digit indicates the tightening direction: 0=CW, 1=CCW.</para>
+        /// <para>The third digit indicates motor rotation: 0=normal,1=inverted.</para>
+        /// </param>
+        /// <param name="controllerSoftwareVersion">The software version is specified by 19 ASCII characters.</param>
+        /// <param name="toolMaxTorque">The tool max toque value is multiplied by 100 and sent as an integer(2 decimals truncated). Six ASCII digits.</param>
+        /// <param name="gearRatio">The gear ratio value is multiplied by 100 and sent as an integer(2 decimals truncated). Six ASCII digits.</param>
+        /// <param name="toolFullSpeed">The tool full speed value is multiplied by 100 and sent as an integer(2 decimals truncated). Six ASCII digits.</param>
+        /// <param name="primaryTool">Primary tool. The primary tool is two byte-long and specified by two ASCII digits.</param>
+        /// <param name="toolModel">12 ASCII characters with padding at the end of the string if needed.The padding is done spaces.</param>
+        /// <param name="toolNumber">
+        ///     The number of the tool. It is the same number as the tool numbers sent in <see cref="Mid0701"/> (Tool List Upload) 
+        ///     <para>In systems with only 1 tool the number sent will always be <c>0001</c></para>
+        /// </param>
+        /// <param name="toolArticleNumber">30 ASCII characters</param>
+        /// <param name="rundownMinSpeed">The rundown min speed value is multiplied by 100 and sent as an integer(2 decimals truncated).6 ASCII digits</param>
+        /// <param name="downshiftMaxSpeed">The downshift max speed value is multiplied by 100 and sent as an integer(2 decimals truncated).6 ASCII digits</param>
+        /// <param name="downshiftMinSpeed">The downshift min speed value is multiplied by 100 and sent as an integer(2 decimals truncated).6 ASCII digits</param>
+        /// <param name="revision">Revision number (default = 7)</param>
+        public Mid0041(string toolSerialNumber, long toolNumberOfTightenings, DateTime lastCalibrationDate,
+            string controllerSerialNumber, decimal calibrationValue, DateTime lastServiceDate,
+            long tighteningsSinceService, ToolType toolType, int motorSize, OpenEndDatas openEndData,
+            string controllerSoftwareVersion, decimal toolMaxTorque, decimal gearRatio, decimal toolFullSpeed,
+            PrimaryTool primaryTool, string toolModel, int toolNumber, string toolArticleNumber, 
+            decimal rundownMinSpeed, decimal downshiftMaxSpeed, decimal downshiftMinSpeed, int revision = 7)
+            : this(toolSerialNumber, toolNumberOfTightenings, lastCalibrationDate, controllerSerialNumber,
+                  calibrationValue, lastServiceDate, tighteningsSinceService, toolType, motorSize, openEndData,
+                  controllerSoftwareVersion, toolMaxTorque, gearRatio, toolFullSpeed, primaryTool, toolModel, 
+                  toolNumber, toolArticleNumber, revision)
+        {
+            RundownMinSpeed = rundownMinSpeed;
+            DownshiftMaxSpeed = downshiftMaxSpeed;
+            DownshiftMinSpeed = downshiftMinSpeed;
         }
 
         /// <summary>
@@ -376,6 +503,21 @@ namespace OpenProtocolInterpreter.Tool
                             {
                                 new DataField((int)DataFields.TOOL_MODEL, 184, 12, ' ')
                             }
+                },
+                {
+                    6, new  List<DataField>()
+                            {
+                                new DataField((int)DataFields.TOOL_NUMBER, 198, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                new DataField((int)DataFields.TOOL_ARTICLE_NUMBER, 204, 30, ' ')
+                            }
+                },
+                {
+                    7, new  List<DataField>()
+                            {
+                                new DataField((int)DataFields.RUNDOWN_MIN_SPEED, 236, 6, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                new DataField((int)DataFields.DOWNSHIFT_MAX_SPEED, 244, 6, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                new DataField((int)DataFields.DOWNSHIFT_MIN_SPEED, 252, 6, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                            }
                 }
             };
         }
@@ -400,8 +542,15 @@ namespace OpenProtocolInterpreter.Tool
             TOOL_FULL_SPEED,
             //Rev 4
             PRIMARY_TOOL,
-            //Rev 5,
-            TOOL_MODEL
+            //Rev 5
+            TOOL_MODEL,
+            //Rev 6
+            TOOL_NUMBER,
+            TOOL_ARTICLE_NUMBER,
+            //Rev 7
+            RUNDOWN_MIN_SPEED,
+            DOWNSHIFT_MAX_SPEED,
+            DOWNSHIFT_MIN_SPEED
         }
 
         public class OpenEndDatas

--- a/src/OpenProtocolInterpreter/Tool/Mid0042.cs
+++ b/src/OpenProtocolInterpreter/Tool/Mid0042.cs
@@ -1,4 +1,7 @@
-﻿namespace OpenProtocolInterpreter.Tool
+﻿using OpenProtocolInterpreter.Converters;
+using System.Collections.Generic;
+
+namespace OpenProtocolInterpreter.Tool
 {
     /// <summary>
     /// Disable tool
@@ -7,11 +10,68 @@
     /// </summary>
     public class Mid0042 : Mid, ITool, IIntegrator
     {
-        private const int LAST_REVISION = 1;
+        private readonly IValueConverter<int> _intConverter;
+
+        private const int LAST_REVISION = 2;
         public const int MID = 42;
 
-        public Mid0042() : base(MID, LAST_REVISION)
+        public int ToolNumber
+        {
+            get => GetField(2, (int)DataFields.TOOL_NUMBER).GetValue(_intConverter.Convert);
+            set => GetField(2, (int)DataFields.TOOL_NUMBER).SetValue(_intConverter.Convert, value);
+        }
+        public DisableType DisableType
+        {
+            get => (DisableType)GetField(2, (int)DataFields.DISABLE_TYPE).GetValue(_intConverter.Convert);
+            set => GetField(2, (int)DataFields.DISABLE_TYPE).SetValue(_intConverter.Convert, (int)value);
+        }
+
+        public Mid0042() : this(LAST_REVISION)
         {
         }
+
+        public Mid0042(int revision = LAST_REVISION) : base(MID, revision)
+        {
+            _intConverter = new Int32Converter();
+        }
+
+        /// <summary>
+        /// Revision 2 constructor
+        /// </summary>
+        /// <param name="toolNumber">The number of the tool to disable. It is the same number as the tool numbers sent in <see cref="Mid0701"/> (Tool List Upload)</param>
+        /// <param name="disableType">
+        ///     The type of disable:
+        ///     <para>00 = Disable(lock)</para>
+        ///     <para>01 = Inhibit NOK</para>
+        ///     <para>02 = Inhibit OK</para>
+        ///     <para>03 = Inhibit No result</para>
+        /// </param>
+        /// <param name="revision">Revision</param>
+        public Mid0042(int toolNumber, DisableType disableType, int revision = 2) : this(revision)
+        {
+            ToolNumber = toolNumber;
+            DisableType = disableType;
+        }
+
+        protected override Dictionary<int, List<DataField>> RegisterDatafields()
+        {
+            return new Dictionary<int, List<DataField>>()
+            {
+                {
+                    2, new List<DataField>()
+                            {
+                                new DataField((int)DataFields.TOOL_NUMBER, 20, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                                new DataField((int)DataFields.DISABLE_TYPE, 26, 2, '0', DataField.PaddingOrientations.LEFT_PADDED)
+                            }
+                },
+            };
+        }
+
+        public enum DataFields
+        {
+            TOOL_NUMBER,
+            DISABLE_TYPE
+        }
     }
+
 }

--- a/src/OpenProtocolInterpreter/Tool/Mid0043.cs
+++ b/src/OpenProtocolInterpreter/Tool/Mid0043.cs
@@ -1,4 +1,7 @@
-﻿namespace OpenProtocolInterpreter.Tool
+﻿using OpenProtocolInterpreter.Converters;
+using System.Collections.Generic;
+
+namespace OpenProtocolInterpreter.Tool
 {
     /// <summary>
     /// Enable tool
@@ -7,12 +10,54 @@
     /// </summary>
     public class Mid0043 : Mid, ITool, IIntegrator
     {
-        private const int LAST_REVISION = 1;
+        private readonly IValueConverter<int> _intConverter;
+
+        private const int LAST_REVISION = 2;
         public const int MID = 43;
 
-        public Mid0043() : base(MID, LAST_REVISION)
+        public int ToolNumber
+        {
+            get => GetField(2, (int)DataFields.TOOL_NUMBER).GetValue(_intConverter.Convert);
+            set => GetField(2, (int)DataFields.TOOL_NUMBER).SetValue(_intConverter.Convert, value);
+        }
+
+        public Mid0043() : this(LAST_REVISION)
         {
 
+        }
+
+        public Mid0043(int revision = LAST_REVISION) : base(MID, revision)
+        {
+            _intConverter = new Int32Converter();
+        }
+
+        /// <summary>
+        /// Revision 2 constructor
+        /// </summary>
+        /// <param name="toolNumber">The number of the tool to disable. It is the same number as the tool numbers sent in <see cref="Mid0701"/> (Tool List Upload)</param>
+        /// <param name="revision">Revision</param>
+        public Mid0043(int toolNumber, int revision = 2) : this(revision)
+        {
+            ToolNumber = toolNumber;
+        }
+
+        protected override Dictionary<int, List<DataField>> RegisterDatafields()
+        {
+            return new Dictionary<int, List<DataField>>()
+            {
+                {
+                    2, new List<DataField>()
+                            {
+                                new DataField((int)DataFields.TOOL_NUMBER, 20, 4, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                            }
+                },
+            };
+        }
+
+        public enum DataFields
+        {
+            TOOL_NUMBER,
+            DISABLE_TYPE
         }
     }
 }

--- a/src/OpenProtocolInterpreter/Tool/Mid0045.cs
+++ b/src/OpenProtocolInterpreter/Tool/Mid0045.cs
@@ -18,35 +18,57 @@ namespace OpenProtocolInterpreter.Tool
     {
         private readonly IValueConverter<decimal> _decimalConverter;
         private readonly IValueConverter<int> _intConverter;
-        private const int LAST_REVISION = 1;
+        private const int LAST_REVISION = 2;
         public const int MID = 45;
 
         public CalibrationUnit CalibrationValueUnit
         {
-            get => (CalibrationUnit)GetField(1,(int)DataFields.CALIBRATION_VALUE_UNIT).GetValue(_intConverter.Convert);
-            set => GetField(1,(int)DataFields.CALIBRATION_VALUE_UNIT).SetValue(_intConverter.Convert, (int)value);
+            get => (CalibrationUnit)GetField(1, (int)DataFields.CALIBRATION_VALUE_UNIT).GetValue(_intConverter.Convert);
+            set => GetField(1, (int)DataFields.CALIBRATION_VALUE_UNIT).SetValue(_intConverter.Convert, (int)value);
         }
         public decimal CalibrationValue
         {
-            get => GetField(1,(int)DataFields.CALIBRATION_VALUE).GetValue(_decimalConverter.Convert);
-            set => GetField(1,(int)DataFields.CALIBRATION_VALUE).SetValue(_decimalConverter.Convert, value);
+            get => GetField(1, (int)DataFields.CALIBRATION_VALUE).GetValue(_decimalConverter.Convert);
+            set => GetField(1, (int)DataFields.CALIBRATION_VALUE).SetValue(_decimalConverter.Convert, value);
+        }
+        public int ChannelNumber
+        {
+            get => GetField(2, (int)DataFields.CHANNEL_NUMBER).GetValue(_intConverter.Convert);
+            set => GetField(2, (int)DataFields.CHANNEL_NUMBER).SetValue(_intConverter.Convert, value);
         }
 
-        public Mid0045() : base(MID, LAST_REVISION)
+        public Mid0045() : this(LAST_REVISION)
+        {
+        }
+
+        public Mid0045(int revision = LAST_REVISION) : base(MID, revision)
         {
             _decimalConverter = new DecimalTrucatedConverter(2);
             _intConverter = new Int32Converter();
         }
 
         /// <summary>
-        /// Revision 1 Constructor
+        /// Revision 1 constructor
         /// </summary>
         /// <param name="calibrationValueUnit">The unit in which the calibration value is sent. The calibration value unit is one byte long and specified by one ASCII digit.</param>
         /// <param name="calibrationValue">The calibration value is multiplied by 100 and sent as an integer (2 decimals truncated). The calibration value is six bytes long and is specified by six ASCII digits.</param>
-        public Mid0045(CalibrationUnit calibrationValueUnit, decimal calibrationValue) : this()
+        /// <param name="revision">Revision</param>
+        public Mid0045(CalibrationUnit calibrationValueUnit, decimal calibrationValue, int revision = 1) : this(revision)
         {
             CalibrationValueUnit = calibrationValueUnit;
             CalibrationValue = calibrationValue;
+        }
+
+        /// <summary>
+        /// Revision 2 constructor
+        /// </summary>
+        /// <param name="calibrationValueUnit">The unit in which the calibration value is sent. The calibration value unit is one byte long and specified by one ASCII digit.</param>
+        /// <param name="calibrationValue">The calibration value is multiplied by 100 and sent as an integer (2 decimals truncated). The calibration value is six bytes long and is specified by six ASCII digits.</param>
+        /// <param name="channelNumber">The number of the channel to set the calibration value.</param>
+        /// <param name="revision">Revision</param>
+        public Mid0045(CalibrationUnit calibrationValueUnit, decimal calibrationValue, int channelNumber, int revision = 2) : this(calibrationValueUnit, calibrationValue, revision)
+        {
+            ChannelNumber = channelNumber;
         }
 
         protected override Dictionary<int, List<DataField>> RegisterDatafields()
@@ -59,6 +81,12 @@ namespace OpenProtocolInterpreter.Tool
                                 new DataField((int)DataFields.CALIBRATION_VALUE_UNIT, 20, 1),
                                 new DataField((int)DataFields.CALIBRATION_VALUE, 23, 6, '0', DataField.PaddingOrientations.LEFT_PADDED)
                             }
+                },
+                {
+                    2, new List<DataField>()
+                            {
+                                new DataField((int)DataFields.CHANNEL_NUMBER, 31, 2, '0', DataField.PaddingOrientations.LEFT_PADDED),
+                            }
                 }
             };
         }
@@ -66,7 +94,8 @@ namespace OpenProtocolInterpreter.Tool
         public enum DataFields
         {
             CALIBRATION_VALUE_UNIT,
-            CALIBRATION_VALUE
+            CALIBRATION_VALUE,
+            CHANNEL_NUMBER
         }
     }
 }


### PR DESCRIPTION
## Breaking changes

- `RevisionsByFields` is no longer a public property due to serialization issues
-  `CalibrationUnit.LBF_LN`  fixed to `CalibrationUnit.LBF_IN`
-  `CalibrationUnit.NCM` changed from `5` to `8`
- `TorqueValuesUnit.LBF_LN`  fixed to `TorqueValuesUnit.LBF_IN`

## New revisions

- `Mid0001`, revisions 6 and 7
- `Mid0012`, revision 5
- `Mid0013`, revisions 3 to 5
- `Mid0032`, revision 4
- `Mid0040`, revision 6 and 7
- `Mid0041`, revision 6 and 7
- `Mid0042`, revision 2
- `Mid0043`, revision 2
- `Mid0045`, revision 2
- `Mid0071`, revision 3
- `Mid0074`, revision 2
- `Mid0140`, revisions 2 and 3 _(pending unit tests)_
- `Mid1201`, revision 2

## Fixes

- Fixed `SpeedOrPressStatusConverter` used in `Mid0101` (#81)

## Related Issues

- #81
