### PR TITLE
Fix issues with package length

### DIFF
--- a/src/OpenProtocolInterpreter/Alarm/Mid0074.cs
+++ b/src/OpenProtocolInterpreter/Alarm/Mid0074.cs
@@ -63,12 +63,6 @@ namespace OpenProtocolInterpreter.Alarm
                             {
                                 new DataField((int)DataFields.ERROR_CODE, 20, 4, ' ', DataField.PaddingOrientations.LEFT_PADDED, false)
                             }
-                },
-                {
-                    2, new List<DataField>()
-                    {
-                        //None??
-                    }
                 }
             };
         }

--- a/src/OpenProtocolInterpreter/Alarm/Mid0076.cs
+++ b/src/OpenProtocolInterpreter/Alarm/Mid0076.cs
@@ -128,9 +128,6 @@ namespace OpenProtocolInterpreter.Alarm
                             }
                 },
                 {
-                    2, new List<DataField>() { }
-                },
-                {
                     3, new List<DataField>()
                             {
                                 new DataField((int)DataFields.TOOL_HEALTH, 57, 1),

--- a/src/OpenProtocolInterpreter/ApplicationSelector/Mid0251.cs
+++ b/src/OpenProtocolInterpreter/ApplicationSelector/Mid0251.cs
@@ -69,7 +69,7 @@ namespace OpenProtocolInterpreter.ApplicationSelector
         {
             Header = ProcessHeader(package);
 
-            GetField(1, (int)DataFields.SOCKET_STATUS).Size = package.Length - 30;
+            GetField(1, (int)DataFields.SOCKET_STATUS).Size = Header.Length - 30;
             ProcessDataFields(package);
             SocketStatus = _boolListConverter.Convert(GetField(1, (int)DataFields.SOCKET_STATUS).Value).ToList();
             return this;

--- a/src/OpenProtocolInterpreter/Communication/Mid0006.cs
+++ b/src/OpenProtocolInterpreter/Communication/Mid0006.cs
@@ -68,7 +68,7 @@ namespace OpenProtocolInterpreter.Communication
         public override Mid Parse(string package)
         {
             Header = ProcessHeader(package);
-            GetField(1, (int)DataFields.EXTRA_DATA).Size = package.Length - 29;
+            GetField(1, (int)DataFields.EXTRA_DATA).Size = Header.Length - 29;
             ProcessDataFields(package);
             return this;
         }

--- a/src/OpenProtocolInterpreter/Communication/Mid0008.cs
+++ b/src/OpenProtocolInterpreter/Communication/Mid0008.cs
@@ -71,7 +71,7 @@ namespace OpenProtocolInterpreter.Communication
         public override Mid Parse(string package)
         {
             Header = ProcessHeader(package);
-            GetField(1, (int)DataFields.EXTRA_DATA).Size = package.Length - 29;
+            GetField(1, (int)DataFields.EXTRA_DATA).Size = Header.Length - 29;
             ProcessDataFields(package);
             return this;
         }

--- a/src/OpenProtocolInterpreter/IOInterface/Mid0214.cs
+++ b/src/OpenProtocolInterpreter/IOInterface/Mid0214.cs
@@ -60,8 +60,7 @@ namespace OpenProtocolInterpreter.IOInterface
                     {
                         new DataField((int)DataFields.DEVICE_NUMBER, 20, 2, '0', DataField.PaddingOrientations.LEFT_PADDED, false)
                     }
-                },
-                { 2, new List<DataField>() }
+                }
             };
         }
 

--- a/src/OpenProtocolInterpreter/IOInterface/Mid0215.cs
+++ b/src/OpenProtocolInterpreter/IOInterface/Mid0215.cs
@@ -117,13 +117,13 @@ namespace OpenProtocolInterpreter.IOInterface
         public override Mid Parse(string package)
         {
             Header = ProcessHeader(package);
-            DataField relayListField;
-            DataField digitalListField;
 
-            if (Header.Revision > 1)
+            var revision = Header.Revision > 1 ? 2 : 1;
+
+            var relayListField = GetField(revision, (int)DataFields.RELAY_LIST);
+            var digitalListField = GetField(revision, (int)DataFields.DIGITAL_INPUT_LIST);
+            if (revision > 1)
             {
-                relayListField = GetField(2, (int)DataFields.RELAY_LIST);
-                digitalListField = GetField(2, (int)DataFields.DIGITAL_INPUT_LIST);
                 int numberOfRelays = _intConverter.Convert(GetValue(GetField(2, (int)DataFields.NUMBER_OF_RELAYS), package));
                 relayListField.Size = numberOfRelays * 4;
 
@@ -131,12 +131,7 @@ namespace OpenProtocolInterpreter.IOInterface
                 numberOfDigitalInputsField.Index = relayListField.Index + 2 + relayListField.Size;
 
                 digitalListField.Index = numberOfDigitalInputsField.Index + 2 + numberOfDigitalInputsField.Size;
-                digitalListField.Size = package.Length - 2 - digitalListField.Index;
-            }
-            else
-            {
-                relayListField = GetField(1, (int)DataFields.RELAY_LIST);
-                digitalListField = GetField(1, (int)DataFields.DIGITAL_INPUT_LIST);
+                digitalListField.Size = Header.Length - 2 - digitalListField.Index;
             }
 
             ProcessDataFields(package);

--- a/src/OpenProtocolInterpreter/Job/Advanced/Mid0129.cs
+++ b/src/OpenProtocolInterpreter/Job/Advanced/Mid0129.cs
@@ -66,9 +66,6 @@ namespace OpenProtocolInterpreter.Job.Advanced
             return new Dictionary<int, List<DataField>>()
             {
                 {
-                    1, new List<DataField>()
-                },
-                {
                     2, new List<DataField>()
                             {
                                 new DataField((int)DataFields.CHANNEL_ID, 20, 2, '0', DataField.PaddingOrientations.LEFT_PADDED),

--- a/src/OpenProtocolInterpreter/Job/Mid0031.cs
+++ b/src/OpenProtocolInterpreter/Job/Mid0031.cs
@@ -104,7 +104,6 @@ namespace OpenProtocolInterpreter.Job
                                 new DataField((int)DataFields.EACH_JOB_ID, 22, 2, '0', DataField.PaddingOrientations.LEFT_PADDED, false)
                             }
                 },
-                { 2, new List<DataField>() }
             };
         }
 

--- a/src/OpenProtocolInterpreter/Job/Mid0033.cs
+++ b/src/OpenProtocolInterpreter/Job/Mid0033.cs
@@ -193,9 +193,6 @@ namespace OpenProtocolInterpreter.Job
                                     new DataField((int)DataFields.PARAMETER_SET_LIST, 89, 0) // defined at runtime
                                 }
                     },
-                    { 2, new List<DataField>() },
-                    { 3, new List<DataField>() },
-                    { 4, new List<DataField>() }
                 };
         }
 

--- a/src/OpenProtocolInterpreter/Job/Mid0035.cs
+++ b/src/OpenProtocolInterpreter/Job/Mid0035.cs
@@ -285,7 +285,6 @@ namespace OpenProtocolInterpreter.Job
                                 new DataField((int)DataFields.TIMESTAMP, 42, 19)
                             }
                 },
-                { 2, new List<DataField>() },
                 {
                     3, new  List<DataField>()
                             {

--- a/src/OpenProtocolInterpreter/Job/Mid0038.cs
+++ b/src/OpenProtocolInterpreter/Job/Mid0038.cs
@@ -71,8 +71,7 @@ namespace OpenProtocolInterpreter.Job
                             {
                                 new DataField((int)DataFields.JOB_ID, 20, 2, '0', DataField.PaddingOrientations.LEFT_PADDED, false),
                             }
-                },
-                { 2, new List<DataField>() }
+                }
             };
         }
 

--- a/src/OpenProtocolInterpreter/Job/Mid0039.cs
+++ b/src/OpenProtocolInterpreter/Job/Mid0039.cs
@@ -71,8 +71,7 @@ namespace OpenProtocolInterpreter.Job
                             {
                                 new DataField((int)DataFields.JOB_ID, 20, 2, '0', DataField.PaddingOrientations.LEFT_PADDED, false),
                             }
-                },
-                {  2, new List<DataField>() }
+                }
             };
         }
 

--- a/src/OpenProtocolInterpreter/MID.cs
+++ b/src/OpenProtocolInterpreter/MID.cs
@@ -16,7 +16,7 @@ namespace OpenProtocolInterpreter
         public Mid(Header header)
         {
             Header = header;
-            RevisionsByFields = RegisterDatafields();
+            RevisionsByFields = new SafeAccessRevisionsFields(RegisterDatafields());
         }
 
         public Mid(int mid, int revision, bool noAckFlag = false): this(new Header()

--- a/src/OpenProtocolInterpreter/MultiSpindle/Mid0091.cs
+++ b/src/OpenProtocolInterpreter/MultiSpindle/Mid0091.cs
@@ -81,6 +81,7 @@ namespace OpenProtocolInterpreter.MultiSpindle
 
         public override Mid Parse(string package)
         {
+            Header = ProcessHeader(package);
             var spindleField = GetField(1, (int)DataFields.SPINDLE_STATUS);
             spindleField.Size = Header.Length - spindleField.Index - 2;
             base.Parse(package);

--- a/src/OpenProtocolInterpreter/MultiSpindle/Mid0091.cs
+++ b/src/OpenProtocolInterpreter/MultiSpindle/Mid0091.cs
@@ -82,7 +82,7 @@ namespace OpenProtocolInterpreter.MultiSpindle
         public override Mid Parse(string package)
         {
             var spindleField = GetField(1, (int)DataFields.SPINDLE_STATUS);
-            spindleField.Size = package.Length - spindleField.Index - 2;
+            spindleField.Size = Header.Length - spindleField.Index - 2;
             base.Parse(package);
             SpindlesStatus = _spindlesStatusConverter.Convert(spindleField.Value).ToList();
             return this;

--- a/src/OpenProtocolInterpreter/MultiSpindle/Mid0100.cs
+++ b/src/OpenProtocolInterpreter/MultiSpindle/Mid0100.cs
@@ -77,7 +77,6 @@ namespace OpenProtocolInterpreter.MultiSpindle
         {
             return new Dictionary<int, List<DataField>>()
             {
-                { 1, new List<DataField>() },
                 {
                     2, new List<DataField>()
                             {

--- a/src/OpenProtocolInterpreter/MultiSpindle/Mid0101.cs
+++ b/src/OpenProtocolInterpreter/MultiSpindle/Mid0101.cs
@@ -207,8 +207,6 @@ namespace OpenProtocolInterpreter.MultiSpindle
                                 new DataField((int)DataFields.SPINDLES_OR_PRESSES_STATUS, 172, 0)
                             }
                 },
-                { 2, new List<DataField>() },
-                { 3, new List<DataField>() },
                 {
                     4, new List<DataField>()
                             {

--- a/src/OpenProtocolInterpreter/OpenProtocolInterpreter.csproj
+++ b/src/OpenProtocolInterpreter/OpenProtocolInterpreter.csproj
@@ -12,6 +12,7 @@
     <Company>Henrique Dal Bello Batista</Company>
     <PackageProjectUrl>https://github.com/Rickedb/OpenProtocolInterpreter</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Rickedb/OpenProtocolInterpreter</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>CSharp Open Protocol Atlas Copco</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReleaseNotes>Improvements

--- a/src/OpenProtocolInterpreter/PLCUserData/Mid0240.cs
+++ b/src/OpenProtocolInterpreter/PLCUserData/Mid0240.cs
@@ -44,7 +44,7 @@ namespace OpenProtocolInterpreter.PLCUserData
         public override Mid Parse(string package)
         {
             Header = ProcessHeader(package);
-            GetField(1, (int)DataFields.USER_DATA).Size = package.Length - 20;
+            GetField(1, (int)DataFields.USER_DATA).Size = Header.Length - 20;
             ProcessDataFields(package);
             return this;
         }

--- a/src/OpenProtocolInterpreter/PLCUserData/Mid0242.cs
+++ b/src/OpenProtocolInterpreter/PLCUserData/Mid0242.cs
@@ -42,7 +42,7 @@ namespace OpenProtocolInterpreter.PLCUserData
         public override Mid Parse(string package)
         {
             Header = ProcessHeader(package);
-            GetField(1, (int)DataFields.USER_DATA).Size = package.Length - 20;
+            GetField(1, (int)DataFields.USER_DATA).Size = Header.Length - 20;
             ProcessDataFields(package);
             return this;
         }

--- a/src/OpenProtocolInterpreter/ParameterSet/Mid0012.cs
+++ b/src/OpenProtocolInterpreter/ParameterSet/Mid0012.cs
@@ -98,14 +98,12 @@ namespace OpenProtocolInterpreter.ParameterSet
                                 new DataField((int)DataFields.PARAMETER_SET_ID, 20, 3, '0', DataField.PaddingOrientations.LEFT_PADDED, false)
                             }
                 },
-                { 2, new List<DataField>() },
                 {
                     3, new  List<DataField>()
                             {
                                 new DataField((int)DataFields.PSET_FILE_VERSION, 23, 8, '0', DataField.PaddingOrientations.LEFT_PADDED, false)
                             }
                 },
-                { 4, new List<DataField>() }
             };
         }
 

--- a/src/OpenProtocolInterpreter/ParameterSet/Mid0013.cs
+++ b/src/OpenProtocolInterpreter/ParameterSet/Mid0013.cs
@@ -237,12 +237,6 @@ namespace OpenProtocolInterpreter.ParameterSet
                             }
                 },
                 {
-                    3, new  List<DataField>()
-                },
-                {
-                    4, new  List<DataField>()
-                },
-                {
                     5, new  List<DataField>()
                             {
                                 new DataField((int)DataFields.LAST_CHANGE_IN_PARAMETER_SET, 120, 19),

--- a/src/OpenProtocolInterpreter/PowerMACS/Mid0105.cs
+++ b/src/OpenProtocolInterpreter/PowerMACS/Mid0105.cs
@@ -70,9 +70,6 @@ namespace OpenProtocolInterpreter.PowerMACS
             return new Dictionary<int, List<DataField>>()
             {
                 {
-                    1, new List<DataField>()
-                },
-                {
                     2, new List<DataField>()
                             {
                                 new DataField((int)DataFields.DATA_NUMBER_SYSTEM, 20, 10, '0', DataField.PaddingOrientations.LEFT_PADDED, false),
@@ -83,9 +80,6 @@ namespace OpenProtocolInterpreter.PowerMACS
                             {
                                 new DataField((int)DataFields.SEND_ONLY_NEW_DATA, 30, 1, false)
                             }
-                },
-                {
-                    4, new List<DataField>()
                 },
             };
         }

--- a/src/OpenProtocolInterpreter/PowerMACS/Mid0106.cs
+++ b/src/OpenProtocolInterpreter/PowerMACS/Mid0106.cs
@@ -181,11 +181,14 @@ namespace OpenProtocolInterpreter.PowerMACS
             specialValues.Index = numberOfSpecialValuesField.Index + numberOfSpecialValuesField.Size + 2;
             if (Header.Revision > 3)
             {
-                specialValues.Size = package.Length - GetField(4, (int)DataFields.SYSTEM_SUB_TYPE).Size - 2;
+                specialValues.Size = Header.Length - GetField(4, (int)DataFields.SYSTEM_SUB_TYPE).Size - 2;
                 GetField(4, (int)DataFields.SYSTEM_SUB_TYPE).Index = specialValues.Index + specialValues.Size;
             }
             else
-                specialValues.Size = package.Length - specialValues.Index;
+            {
+                specialValues.Size = Header.Length - specialValues.Index;
+            }
+
             ProcessDataFields(package);
 
             _boltDataListConverter = new BoltDataListConverter(_intConverter, _boolConverter, _decimalConverter, numberOfBolts);

--- a/src/OpenProtocolInterpreter/PowerMACS/Mid0106.cs
+++ b/src/OpenProtocolInterpreter/PowerMACS/Mid0106.cs
@@ -222,8 +222,6 @@ namespace OpenProtocolInterpreter.PowerMACS
                                         new DataField((int)DataFields.SPECIAL_VALUES, 0, 0, false)
                                 }
                     },
-                    { 2, new List<DataField>() },
-                    { 3, new List<DataField>() },
                     {
                         4, new List<DataField>()
                                 {

--- a/src/OpenProtocolInterpreter/PowerMACS/Mid0107.cs
+++ b/src/OpenProtocolInterpreter/PowerMACS/Mid0107.cs
@@ -220,8 +220,6 @@ namespace OpenProtocolInterpreter.PowerMACS
                                         new DataField((int)DataFields.SPECIAL_VALUES, 0, 0, false)
                                 }
                     },
-                    { 2, new List<DataField>() },
-                    { 3, new List<DataField>() },
                     {
                         4, new List<DataField>()
                                 {

--- a/src/OpenProtocolInterpreter/PowerMACS/Mid0107.cs
+++ b/src/OpenProtocolInterpreter/PowerMACS/Mid0107.cs
@@ -182,7 +182,7 @@ namespace OpenProtocolInterpreter.PowerMACS
 
             var specialValuesField = GetField(1, (int)DataFields.SPECIAL_VALUES);
             specialValuesField.Index = 2 + numberOfSpecialValuesField.Index + numberOfSpecialValuesField.Size;
-            specialValuesField.Size = package.Length - specialValuesField.Index;
+            specialValuesField.Size = Header.Length - specialValuesField.Index;
 
             ProcessDataFields(package);
             _specialValueConverter = new SpecialValueListConverter(_intConverter, NumberOfSpecialValues, true);

--- a/src/OpenProtocolInterpreter/PowerMACS/Mid0108.cs
+++ b/src/OpenProtocolInterpreter/PowerMACS/Mid0108.cs
@@ -56,9 +56,6 @@ namespace OpenProtocolInterpreter.PowerMACS
                                 new DataField((int)DataFields.BOLT_DATA, 20, 1, false),
                             }
                 },
-                { 2, new List<DataField>() },
-                { 3, new List<DataField>() },
-                { 4, new List<DataField>() }
             };
         }
 

--- a/src/OpenProtocolInterpreter/Result/Mid1201.cs
+++ b/src/OpenProtocolInterpreter/Result/Mid1201.cs
@@ -120,7 +120,7 @@ namespace OpenProtocolInterpreter.Result
 
             var dataFieldListField = GetField(1, (int)DataFields.DATA_FIELD_LIST);
             dataFieldListField.Index = totalNumberDataField.Index + totalNumberDataField.Size;
-            dataFieldListField.Size = package.Length - dataFieldListField.Index;
+            dataFieldListField.Size = Header.Length - dataFieldListField.Index;
 
             ObjectDataList = _objectDataListConverter.Convert(objectDataField.Value).ToList();
             VariableDataFields = _varDataFieldListConverter.Convert(dataFieldListField.Value).ToList();

--- a/src/OpenProtocolInterpreter/Result/Mid1202.cs
+++ b/src/OpenProtocolInterpreter/Result/Mid1202.cs
@@ -84,7 +84,7 @@ namespace OpenProtocolInterpreter.Result
         {
             Header = ProcessHeader(package);
             var variableDataField = GetField(1, (int)DataFields.VARIABLE_DATA_FIELDS);
-            variableDataField.Size = package.Length - variableDataField.Index;
+            variableDataField.Size = Header.Length - variableDataField.Index;
             ProcessDataFields(package);
 
             VariableDataFields = _variableDataFieldListConverter.Convert(variableDataField.Value).ToList();

--- a/src/OpenProtocolInterpreter/Tightening/Mid0064.cs
+++ b/src/OpenProtocolInterpreter/Tightening/Mid0064.cs
@@ -69,11 +69,6 @@ namespace OpenProtocolInterpreter.Tightening
                                 new DataField((int)DataFields.TIGHTENING_ID, 20, 10, '0', DataField.PaddingOrientations.LEFT_PADDED, false)
                             }
                 },
-                { 2, new List<DataField>() },
-                { 3, new List<DataField>() },
-                { 4, new List<DataField>() },
-                { 5, new List<DataField>() },
-                { 6, new List<DataField>() }
             };
         }
 

--- a/src/OpenProtocolInterpreter/_internals/SafeAccessRevisionsFields.cs
+++ b/src/OpenProtocolInterpreter/_internals/SafeAccessRevisionsFields.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace OpenProtocolInterpreter
+{
+    internal class SafeAccessRevisionsFields : Dictionary<int, List<DataField>>
+    {
+        public new List<DataField> this[int index]
+        {
+            get
+            {
+                if (!ContainsKey(index))
+                {
+                    Add(index, new List<DataField>());
+                }
+
+                return this[index];
+            }
+        }
+
+        public SafeAccessRevisionsFields()
+        {
+
+        }
+
+        public SafeAccessRevisionsFields(IDictionary<int, List<DataField>> dictionary) : base(dictionary)
+        {
+        }
+
+        public SafeAccessRevisionsFields(IDictionary<int, List<DataField>> dictionary, IEqualityComparer<int> comparer) : base(dictionary, comparer)
+        {
+        }
+
+        public SafeAccessRevisionsFields(IEqualityComparer<int> comparer) : base(comparer)
+        {
+        }
+
+        public SafeAccessRevisionsFields(int capacity) : base(capacity)
+        {
+        }
+
+        public SafeAccessRevisionsFields(int capacity, IEqualityComparer<int> comparer) : base(capacity, comparer)
+        {
+        }
+
+        protected SafeAccessRevisionsFields(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fix any parsing that should consider package full length. Due to `NUL` character, package raw length would always have +1 character at it's length.

## Related issues

- #59 
- #94 